### PR TITLE
Allow any order on input.

### DIFF
--- a/tar_test.go
+++ b/tar_test.go
@@ -18,6 +18,7 @@ import (
 	"archive/tar"
 	"bytes"
 	"io"
+	"io/ioutil"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -84,6 +85,9 @@ func TestFromTar(t *testing.T) {
 			r, err := FromTar(tc.input, RPMMetaData{})
 			if err != nil {
 				t.Errorf("FromTar returned err: %v", err)
+			}
+			if err := r.Write(ioutil.Discard); err != nil {
+				t.Errorf("r.Write() returned err: %v", err)
 			}
 			if r == nil {
 				t.Fatalf("FromTar returned nil pointer")


### PR DESCRIPTION
Before this change, we required our users to input files in the right
alphabetical sorting, in order to be able to process the files on the
fly. But this complicates the interfaces a lot for a memory optimization
that is irrelevant for most cases.

After this change we'll simply collect the files to a map.