### PR TITLE
minimal bazel rule for pkg_tar2rpm

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -3,7 +3,9 @@
 # this is currently added to assist in external testing.
 
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
 load("@bazel_gazelle//:def.bzl", "gazelle")
+load("//:def.bzl", "pkg_tar2rpm")
 
 # gazelle:prefix github.com/google/rpmpack
 gazelle(name = "gazelle")
@@ -32,6 +34,23 @@ go_test(
         "header_test.go",
         "tar_test.go",
     ],
+    data = glob(["testdata/**"]),
     embed = [":go_default_library"],
     deps = ["@com_github_google_go_cmp//cmp:go_default_library"],
+)
+
+pkg_tar(
+    name = "rpmtest-tar",
+    srcs = ["//:testdata/content1.txt"],
+    package_dir = "var/lib/rpmpack",
+    mode = "0644",
+    ownername = "root.root",
+)
+
+pkg_tar2rpm(
+    name = "rpmtest",
+    data = ":rpmtest-tar",
+    pkg_name = "rpmtest",
+    release = "3.4",
+    version = "1.2",
 )

--- a/def.bzl
+++ b/def.bzl
@@ -1,0 +1,34 @@
+def _pkg_tar2rpm_impl(ctx):
+    files = [ctx.file.data]
+    args = ctx.actions.args()
+    args.add("--name", ctx.attr.pkg_name)
+    args.add("--version", ctx.attr.version)
+    args.add("--release", ctx.attr.release)
+    args.add("--file", ctx.outputs.out)
+    args.add(ctx.file.data)
+    ctx.actions.run(
+        executable = ctx.executable.tar2rpm,
+        arguments = [args],
+        inputs = files,
+        outputs = [ctx.outputs.out],
+        mnemonic = "tar2rpm",
+    )
+
+# A rule for generating rpm files
+pkg_tar2rpm = rule(
+    implementation = _pkg_tar2rpm_impl,
+    attrs = {
+        "data": attr.label(mandatory = True, allow_single_file = [".tar"]),
+        "pkg_name": attr.string(mandatory = True),
+        "version": attr.string(mandatory = True),
+        "release": attr.string(mandatory = True),
+        "tar2rpm": attr.label(
+            default = Label("//cmd/tar2rpm"),
+            cfg = "host",
+            executable = True,
+        ),
+    },
+    outputs = {
+        "out": "%{name}.rpm",
+    },
+)

--- a/rpm.go
+++ b/rpm.go
@@ -214,6 +214,9 @@ func (r *RPM) writeFileIndexes(h *index) error {
 
 // AddFile adds an RPMFile to an existing rpm.
 func (r *RPM) AddFile(f RPMFile) error {
+	if f.Name == "/" { // rpm does not allow the root dir to be included.
+		return nil
+	}
 	r.files[f.Name] = f
 	return nil
 }

--- a/testdata/content1.txt
+++ b/testdata/content1.txt
@@ -1,0 +1,1 @@
+test data for tar2rpm


### PR DESCRIPTION
A very basic bazel rule to create rpm files.