### PR TITLE
Fix lint errors: mostly unused vars and unchecked errors.

### DIFF
--- a/cmd/rpmsample/main.go
+++ b/cmd/rpmsample/main.go
@@ -65,6 +65,8 @@ func main() {
 			Owner: "root",
 			Group: "root",
 		})
-	r.Write(os.Stdout)
+	if err := r.Write(os.Stdout); err != nil {
+		log.Fatalf("write failed: %v", err)
+	}
 
 }

--- a/tags.go
+++ b/tags.go
@@ -18,7 +18,6 @@ package rpmpack
 const (
 	tagHeaderI18NTable = 0x64 // 100
 	// Signature tags are obiously overlapping regular header tags..
-	sigSHA1        = 0x010d // 269
 	sigSHA256      = 0x0111 // 273
 	sigSize        = 0x03e8 // 1000
 	sigPayloadSize = 0x03ef // 1007
@@ -43,7 +42,6 @@ const (
 	tagProvides          = 0x0417 // 1047
 	tagFileINodes        = 0x0448 // 1096
 	tagFileLangs         = 0x0449 // 1097
-	tagPrefixes          = 0x044a // 1098
 	tagProvideFlags      = 0x0458 // 1112
 	tagProvideVersion    = 0x0459 // 1113
 	tagDirindexes        = 0x045c // 1116

--- a/tar.go
+++ b/tar.go
@@ -57,7 +57,7 @@ func FromTar(inp io.Reader, md RPMMetaData) (*RPM, error) {
 		}
 		mtime := uint32(h.ModTime.Unix())
 
-		if err := r.AddFile(
+		r.AddFile(
 			RPMFile{
 				Name:  path.Join("/", h.Name),
 				Body:  body,
@@ -65,8 +65,6 @@ func FromTar(inp io.Reader, md RPMMetaData) (*RPM, error) {
 				Owner: h.Uname,
 				Group: h.Gname,
 				MTime: mtime,
-			}); err != nil {
-			return nil, errors.Wrapf(err, "failed to add file (%q)", h.Name)
-		}
+			})
 	}
 }


### PR DESCRIPTION
Based on findings from golangci