### PR TITLE
Add prein and other scriptlets to the library

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ jobs:
     script: go test ${gobuild_args} ./...
   - stage: bazel build and test
     before_install:
-      - curl -L -o "bazel-installer" https://github.com/bazelbuild/bazel/releases/download/0.23.1/bazel-0.23.1-installer-linux-x86_64.sh
+      - curl -L -o "bazel-installer" https://github.com/bazelbuild/bazel/releases/download/0.29.0/bazel-0.29.0-installer-linux-x86_64.sh
       - bash bazel-installer --user
     script:
       - ~/bin/bazel build --curses=no //...

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -70,6 +70,7 @@ container_image(
     testonly = True,
     base = ":centos_with_rpm",
     cmd = "echo ===marker===  && rpm -i /root/rpmtest.rpm && rpm -Vv rpmtest",
+    legacy_run_behavior = False,
 )
 
 container_image(
@@ -77,6 +78,7 @@ container_image(
     testonly = True,
     base = ":centos_with_rpm",
     cmd = "echo ===marker===  && rpm -i /root/rpmtest.rpm && ls -l /var/lib/rpmpack",
+    legacy_run_behavior = False,
 )
 
 sh_test(

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -54,6 +54,7 @@ pkg_tar2rpm(
     pkg_name = "rpmtest",
     release = "3.4",
     version = "1.2",
+    prein = "echo \"This is preinst\" > /tmp/preinst.txt",
 )
 
 container_image(
@@ -81,13 +82,23 @@ container_image(
     legacy_run_behavior = False,
 )
 
+container_image(
+    name = "centos_preinst",
+    testonly = True,
+    base = ":centos_with_rpm",
+    cmd = "echo ===marker===  && rpm -i /root/rpmtest.rpm && cat /tmp/preinst.txt",
+    legacy_run_behavior = False,
+)
+
 sh_test(
     name = "docker_tests",
     srcs = ["docker_tests.sh"],
     data = [
         ":centos_V",
         ":centos_ls",
+        ":centos_preinst",
         ":testdata/golden_V.txt",
         ":testdata/golden_ls.txt",
+        ":testdata/golden_preinst.txt",
     ],
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -4,22 +4,29 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "io_bazel_rules_go",
-    sha256 = "492c3ac68ed9dcf527a07e6a1b2dcbf199c6bf8b35517951467ac32e421c06c1",
-    urls = ["https://github.com/bazelbuild/rules_go/releases/download/0.17.0/rules_go-0.17.0.tar.gz"],
+    sha256 = "ae8c36ff6e565f674c7a3692d6a9ea1096e4c1ade497272c2108a810fb39acd2",
+    urls = ["https://github.com/bazelbuild/rules_go/releases/download/0.19.4/rules_go-0.19.4.tar.gz"],
 )
 
 http_archive(
     name = "bazel_gazelle",
-    sha256 = "7949fc6cc17b5b191103e97481cf8889217263acf52e00b560683413af204fcb",
-    urls = ["https://github.com/bazelbuild/bazel-gazelle/releases/download/0.16.0/bazel-gazelle-0.16.0.tar.gz"],
+    sha256 = "7fc87f4170011201b1690326e8c16c5d802836e3a0d617d8f75c3af2b23180c4",
+    urls = ["https://github.com/bazelbuild/bazel-gazelle/releases/download/0.18.2/bazel-gazelle-0.18.2.tar.gz"],
 )
 
 http_archive(
     name = "io_bazel_rules_docker",
-    sha256 = "aed1c249d4ec8f703edddf35cbe9dfaca0b5f5ea6e4cd9e83e99f3b0d1136c3d",
-    strip_prefix = "rules_docker-0.7.0",
-    urls = ["https://github.com/bazelbuild/rules_docker/archive/v0.7.0.tar.gz"],
+    sha256 = "e513c0ac6534810eb7a14bf025a0f159726753f97f74ab7863c650d26e01d677",
+    strip_prefix = "rules_docker-0.9.0",
+    urls = ["https://github.com/bazelbuild/rules_docker/archive/v0.9.0.tar.gz"],
 )
+
+load(
+    "@io_bazel_rules_docker//repositories:repositories.bzl",
+    container_repositories = "repositories",
+)
+
+container_repositories()
 
 load("@io_bazel_rules_go//go:deps.bzl", "go_rules_dependencies", "go_register_toolchains")
 
@@ -32,15 +39,16 @@ load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies", "go_repository")
 gazelle_dependencies()
 
 load(
+    "@io_bazel_rules_docker//repositories:deps.bzl",
+    container_deps = "deps",
+)
+
+container_deps()
+
+load(
     "@io_bazel_rules_docker//container:container.bzl",
     "container_pull",
 )
-load(
-    "@io_bazel_rules_docker//repositories:repositories.bzl",
-    container_repositories = "repositories",
-)
-
-container_repositories()
 
 go_repository(
     name = "com_github_pkg_errors",
@@ -62,7 +70,7 @@ go_repository(
 
 container_pull(
     name = "centos",
-    digest = "sha256:184e5f35598e333bfa7de10d8fb1cebb5ee4df5bc0f970bf2b1e7c7345136426",
+    digest = "sha256:365fc7f33107869dfcf2b3ba220ce0aa42e16d3f8e8b3c21d72af1ee622f0cf0",
     registry = "index.docker.io",
     repository = "library/centos",
 )

--- a/cmd/tar2rpm/main.go
+++ b/cmd/tar2rpm/main.go
@@ -30,6 +30,11 @@ var (
 	release = flag.String("release", "", "the rpm release")
 	arch    = flag.String("arch", "noarch", "the rpm architecture")
 
+	prein  = flag.String("prein", "", "prein scriptlet contents (not filename)")
+	postin = flag.String("postin", "", "postin scriptlet contents (not filename)")
+	preun  = flag.String("preun", "", "preun scriptlet contents (not filename)")
+	postun = flag.String("postun", "", "postun scriptlet contents (not filename)")
+
 	outputfile = flag.String("file", "", "write rpm to `FILE` instead of stdout")
 )
 
@@ -86,6 +91,11 @@ func main() {
 			Release: *release,
 			Arch:    *arch,
 		})
+	r.AddPrein(*prein)
+	r.AddPostin(*postin)
+	r.AddPreun(*preun)
+	r.AddPostun(*postun)
+
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "tar2rpm error: %v\n", err)
 		os.Exit(1)

--- a/def.bzl
+++ b/def.bzl
@@ -4,6 +4,10 @@ def _pkg_tar2rpm_impl(ctx):
     args.add("--name", ctx.attr.pkg_name)
     args.add("--version", ctx.attr.version)
     args.add("--release", ctx.attr.release)
+    args.add("--prein", ctx.attr.prein)
+    args.add("--postin", ctx.attr.postin)
+    args.add("--preun", ctx.attr.preun)
+    args.add("--postun", ctx.attr.postun)
     args.add("--file", ctx.outputs.out)
     args.add(ctx.file.data)
     ctx.actions.run(
@@ -22,6 +26,10 @@ pkg_tar2rpm = rule(
         "pkg_name": attr.string(mandatory = True),
         "version": attr.string(mandatory = True),
         "release": attr.string(mandatory = True),
+        "prein": attr.string(),
+        "postin": attr.string(),
+        "preun": attr.string(),
+        "postun": attr.string(),
         "tar2rpm": attr.label(
             default = Label("//cmd/tar2rpm"),
             cfg = "host",

--- a/docker_tests.sh
+++ b/docker_tests.sh
@@ -37,7 +37,9 @@ diff_test centos_V testdata/golden_V.txt
 V_result="$?"
 diff_test centos_ls testdata/golden_ls.txt
 ls_result="$?"
+diff_test centos_preinst testdata/golden_preinst.txt
+preinst_result="$?"
 
-if [[ "$V_result" -ne 0 || "$ls_result" -ne 0 ]]; then
+if [[ "$V_result" -ne 0 || "$ls_result" -ne 0 || "$preinst_result" -ne 0 ]]; then
   exit 1
 fi

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,6 @@ go 1.12
 
 require (
 	github.com/cavaliercoder/go-cpio v0.0.0-20180626203310-925f9528c45e
-	github.com/google/go-cmp v0.2.0
+	github.com/google/go-cmp v0.3.1
 	github.com/pkg/errors v0.8.1
 )

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,6 @@
 github.com/cavaliercoder/go-cpio v0.0.0-20180626203310-925f9528c45e h1:hHg27A0RSSp2Om9lubZpiMgVbvn39bsUmW9U5h0twqc=
 github.com/cavaliercoder/go-cpio v0.0.0-20180626203310-925f9528c45e/go.mod h1:oDpT4efm8tSYHXV5tHSdRvBet/b/QzxZ+XyyPehvm3A=
-github.com/google/go-cmp v0.2.0 h1:+dTQ8DZQJz0Mb/HjFlkptS1FeQ4cWSnN941F8aEG4SQ=
-github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
-github.com/google/rpmpack v0.0.0-20190308191121-5b81ccf5311d h1:WcHNXrfd02sEB/CaqAWhw+tvtIsbEfFH4OQbl5DUISo=
-github.com/google/rpmpack v0.0.0-20190308191121-5b81ccf5311d/go.mod h1:ZB/rz+NQ9uWOy15ZnvlIfbzCYntyNpAR8p+t/k8iyQ4=
+github.com/google/go-cmp v0.3.1 h1:Xye71clBPdm5HgqGwUkwhbynsUJZhDbS20FvLhQ2izg=
+github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/rpm.go
+++ b/rpm.go
@@ -74,6 +74,10 @@ type RPM struct {
 	closed      bool
 	gzPayload   *gzip.Writer
 	files       map[string]RPMFile
+	prein       string
+	postin      string
+	preun       string
+	postun      string
 }
 
 // NewRPM creates and returns a new RPM struct.
@@ -175,6 +179,22 @@ func (r *RPM) writeGenIndexes(h *index) {
 	// rpm utilities look for the sourcerpm tag to deduce if this is not a source rpm (if it has a sourcerpm,
 	// it is NOT a source rpm).
 	h.Add(tagSourceRPM, entry(fmt.Sprintf("%s-%s-%s.src.rpm", r.Name, r.Version, r.Release)))
+	if r.prein != "" {
+		h.Add(tagPrein, entry(r.prein))
+		h.Add(tagPreinProg, entry("/bin/sh"))
+	}
+	if r.postin != "" {
+		h.Add(tagPostin, entry(r.postin))
+		h.Add(tagPostinProg, entry("/bin/sh"))
+	}
+	if r.preun != "" {
+		h.Add(tagPreun, entry(r.preun))
+		h.Add(tagPreunProg, entry("/bin/sh"))
+	}
+	if r.postun != "" {
+		h.Add(tagPostun, entry(r.postun))
+		h.Add(tagPostunProg, entry("/bin/sh"))
+	}
 }
 
 // WriteFileIndexes writes file related index headers to the header
@@ -213,6 +233,26 @@ func (r *RPM) writeFileIndexes(h *index) {
 	h.Add(tagFileFlags, entry(fileFlags))
 	h.Add(tagFileRDevs, entry(fileRDevs))
 	h.Add(tagFileLangs, entry(fileLangs))
+}
+
+// AddPrein adds a prein sciptlet
+func (r *RPM) AddPrein(s string) {
+	r.prein = s
+}
+
+// AddPostin adds a postin sciptlet
+func (r *RPM) AddPostin(s string) {
+	r.postin = s
+}
+
+// AddPreun adds a preun sciptlet
+func (r *RPM) AddPreun(s string) {
+	r.preun = s
+}
+
+// AddPostun adds a postun sciptlet
+func (r *RPM) AddPostun(s string) {
+	r.postun = s
 }
 
 // AddFile adds an RPMFile to an existing rpm.

--- a/tags.go
+++ b/tags.go
@@ -22,12 +22,18 @@ const (
 	sigSize        = 0x03e8 // 1000
 	sigPayloadSize = 0x03ef // 1007
 
-	tagName              = 0x03e8 // 1000
-	tagVersion           = 0x03e9 // 1001
-	tagRelease           = 0x03ea // 1002
-	tagSize              = 0x03f1 // 1009
-	tagOS                = 0x03fd // 1021
-	tagArch              = 0x03fe // 1022
+	tagName    = 0x03e8 // 1000
+	tagVersion = 0x03e9 // 1001
+	tagRelease = 0x03ea // 1002
+	tagSize    = 0x03f1 // 1009
+	tagOS      = 0x03fd // 1021
+	tagArch    = 0x03fe // 1022
+
+	tagPrein  = 0x03ff // 1023
+	tagPostin = 0x0400 // 1024
+	tagPreun  = 0x0401 // 1025
+	tagPostun = 0x0402 // 1026
+
 	tagFileSizes         = 0x0404 // 1028
 	tagFileModes         = 0x0406 // 1030
 	tagFileRDevs         = 0x0409 // 1033
@@ -40,6 +46,10 @@ const (
 	tagSourceRPM         = 0x0414 // 1044
 	tagFileVerifyFlags   = 0x0415 // 1045
 	tagProvides          = 0x0417 // 1047
+	tagPreinProg         = 0x043d // 1085
+	tagPostinProg        = 0x043e // 1086
+	tagPreunProg         = 0x043f // 1087
+	tagPostunProg        = 0x0440 // 1088
 	tagFileINodes        = 0x0448 // 1096
 	tagFileLangs         = 0x0449 // 1097
 	tagProvideFlags      = 0x0458 // 1112

--- a/testdata/golden_ls.txt
+++ b/testdata/golden_ls.txt
@@ -1,2 +1,2 @@
 total 4
--rw-r--r-- 1 root root 22 Jan  1  1970 content1.txt
+-rw-r--r-- 1 root root 22 Jan  1  2000 content1.txt

--- a/testdata/golden_preinst.txt
+++ b/testdata/golden_preinst.txt
@@ -1,0 +1,1 @@
+This is preinst


### PR DESCRIPTION
Add scriptlets to the library, tar2rpm, and bazel definition.
    
Should fix #12 albeit with a slightly different API, because of the way
the scriptlets are defined in rpm, where each scriptlet has its own tag
number and prog tag (The prog tags are required, and seem to always be
`/bin/sh`)

Notice that it is chained to pull request #13 so only the second commit is relevant