### PR TITLE
feat: add additional rpm field support

### DIFF
--- a/cmd/tar2rpm/main.go
+++ b/cmd/tar2rpm/main.go
@@ -25,6 +25,7 @@ import (
 )
 
 type stringSlice []string
+
 func (i *stringSlice) String() string {
 	return "my string representation"
 }
@@ -42,17 +43,22 @@ func (i *stringSlice) Value() []string {
 }
 
 var (
-	provides, obsoletes, suggests, recommends, requires, conflicts stringSlice
-	name    = flag.String("name", "", "the package name")
-	version = flag.String("version", "", "the package version")
-	release = flag.String("release", "", "the rpm release")
-	arch    = flag.String("arch", "noarch", "the rpm architecture")
-	osName = flag.String("os", "linux", "the rpm os")
+	provides,
+	obsoletes,
+	suggests,
+	recommends,
+	requires,
+	conflicts stringSlice
+	name        = flag.String("name", "", "the package name")
+	version     = flag.String("version", "", "the package version")
+	release     = flag.String("release", "", "the rpm release")
+	arch        = flag.String("arch", "noarch", "the rpm architecture")
+	osName      = flag.String("os", "linux", "the rpm os")
 	description = flag.String("description", "", "the rpm description")
-	vendor = flag.String("vendor", "", "the rpm vendor")
-	packager = flag.String("packager", "", "the rpm packager")
-	url = flag.String("url", "", "the rpm url")
-	licence = flag.String("licence", "", "the rpm licence name")
+	vendor      = flag.String("vendor", "", "the rpm vendor")
+	packager    = flag.String("packager", "", "the rpm packager")
+	url         = flag.String("url", "", "the rpm url")
+	licence     = flag.String("licence", "", "the rpm licence name")
 
 	prein  = flag.String("prein", "", "prein scriptlet contents (not filename)")
 	postin = flag.String("postin", "", "postin scriptlet contents (not filename)")
@@ -116,21 +122,22 @@ func main() {
 	r, err := rpmpack.FromTar(
 		i,
 		rpmpack.RPMMetaData{
-			Name:    *name,
-			Version: *version,
-			Release: *release,
-			Arch:    *arch,
-			OS: *osName,
-			Vendor: *vendor,
-			Packager: *packager,
-			URL: *url,
-			Licence: *licence,
-			Provides: provides.Value(),
-			Obsoletes: obsoletes.Value(),
-			Suggests: suggests.Value(),
-			Recommends: recommends.Value(),
-			Requires: requires.Value(),
-			Conflicts: conflicts.Value(),
+			Name:        *name,
+			Description: *description,
+			Version:     *version,
+			Release:     *release,
+			Arch:        *arch,
+			OS:          *osName,
+			Vendor:      *vendor,
+			Packager:    *packager,
+			URL:         *url,
+			Licence:     *licence,
+			Provides:    provides.Value(),
+			Obsoletes:   obsoletes.Value(),
+			Suggests:    suggests.Value(),
+			Recommends:  recommends.Value(),
+			Requires:    requires.Value(),
+			Conflicts:   conflicts.Value(),
 		})
 	r.AddPrein(*prein)
 	r.AddPostin(*postin)

--- a/cmd/tar2rpm/main.go
+++ b/cmd/tar2rpm/main.go
@@ -24,11 +24,35 @@ import (
 	"github.com/google/rpmpack"
 )
 
+type stringSlice []string
+func (i *stringSlice) String() string {
+	return "my string representation"
+}
+
+func (i *stringSlice) Set(value string) error {
+	*i = append(*i, value)
+	return nil
+}
+func (i *stringSlice) Value() []string {
+	v := make([]string, len(*i))
+	for idx := range *i {
+		v[idx] = (*i)[idx]
+	}
+	return v
+}
+
 var (
+	provides, obsoletes, suggests, recommends, requires, conflicts stringSlice
 	name    = flag.String("name", "", "the package name")
 	version = flag.String("version", "", "the package version")
 	release = flag.String("release", "", "the rpm release")
 	arch    = flag.String("arch", "noarch", "the rpm architecture")
+	osName = flag.String("os", "linux", "the rpm os")
+	description = flag.String("description", "", "the rpm description")
+	vendor = flag.String("vendor", "", "the rpm vendor")
+	packager = flag.String("packager", "", "the rpm packager")
+	url = flag.String("url", "", "the rpm url")
+	licence = flag.String("licence", "", "the rpm licence name")
 
 	prein  = flag.String("prein", "", "prein scriptlet contents (not filename)")
 	postin = flag.String("postin", "", "postin scriptlet contents (not filename)")
@@ -48,10 +72,16 @@ Options:
 }
 
 func main() {
+	flag.Var(&provides, "provides", "rpm provides values, can be just name or in the form of name=version (eg. bla=1.2.3)")
+	flag.Var(&obsoletes, "obsoletes", "rpm obsoletes values, can be just name or in the form of name=version (eg. bla=1.2.3)")
+	flag.Var(&suggests, "suggests", "rpm suggests values, can be just name or in the form of name=version (eg. bla=1.2.3)")
+	flag.Var(&recommends, "recommends", "rpm recommends values, can be just name or in the form of name=version (eg. bla=1.2.3)")
+	flag.Var(&requires, "requires", "rpm requires values, can be just name or in the form of name=version (eg. bla=1.2.3)")
+	flag.Var(&conflicts, "conflicts", "rpm provides values, can be just name or in the form of name=version (eg. bla=1.2.3)")
 	flag.Usage = usage
 	flag.Parse()
-	if *name == "" || *version == "" || *release == "" {
-		fmt.Fprintln(os.Stderr, "name, version, and release are all required")
+	if *name == "" || *version == "" {
+		fmt.Fprintln(os.Stderr, "name and version are required")
 		flag.Usage()
 		os.Exit(2)
 	}
@@ -90,6 +120,17 @@ func main() {
 			Version: *version,
 			Release: *release,
 			Arch:    *arch,
+			OS: *osName,
+			Vendor: *vendor,
+			Packager: *packager,
+			URL: *url,
+			Licence: *licence,
+			Provides: provides.Value(),
+			Obsoletes: obsoletes.Value(),
+			Suggests: suggests.Value(),
+			Recommends: recommends.Value(),
+			Requires: requires.Value(),
+			Conflicts: conflicts.Value(),
 		})
 	r.AddPrein(*prein)
 	r.AddPostin(*postin)

--- a/def.bzl
+++ b/def.bzl
@@ -25,7 +25,7 @@ pkg_tar2rpm = rule(
         "data": attr.label(mandatory = True, allow_single_file = [".tar"]),
         "pkg_name": attr.string(mandatory = True),
         "version": attr.string(mandatory = True),
-        "release": attr.string(mandatory = True),
+        "release": attr.string(),
         "prein": attr.string(),
         "postin": attr.string(),
         "preun": attr.string(),

--- a/tags.go
+++ b/tags.go
@@ -15,6 +15,7 @@
 package rpmpack
 
 // Define only tags which we actually use
+// https://github.com/rpm-software-management/rpm/blob/master/lib/rpmtag.h
 const (
 	tagHeaderI18NTable = 0x64 // 100
 	// Signature tags are obiously overlapping regular header tags..
@@ -22,12 +23,17 @@ const (
 	sigSize        = 0x03e8 // 1000
 	sigPayloadSize = 0x03ef // 1007
 
-	tagName    = 0x03e8 // 1000
-	tagVersion = 0x03e9 // 1001
-	tagRelease = 0x03ea // 1002
-	tagSize    = 0x03f1 // 1009
-	tagOS      = 0x03fd // 1021
-	tagArch    = 0x03fe // 1022
+	tagName        = 0x03e8 // 1000
+	tagVersion     = 0x03e9 // 1001
+	tagRelease     = 0x03ea // 1002
+	tagDescription = 0x03ed // 1005
+	tagSize        = 0x03f1 // 1009
+	tagVendor      = 0x03f3 // 1011
+	tagLicence     = 0x03f6 // 1014
+	tagPackager    = 0x03f7 // 1015
+	tagURL         = 0x03fc // 1020
+	tagOS          = 0x03fd // 1021
+	tagArch        = 0x03fe // 1022
 
 	tagPrein  = 0x03ff // 1023
 	tagPostin = 0x0400 // 1024
@@ -46,14 +52,23 @@ const (
 	tagSourceRPM         = 0x0414 // 1044
 	tagFileVerifyFlags   = 0x0415 // 1045
 	tagProvides          = 0x0417 // 1047
+	tagRequireFlags      = 0x0418 // 1048
+	tagRequire           = 0x0419 // 1049
+	tagRequireVersion    = 0x041a // 1050
+	tagConflictFlags     = 0x041d // 1053
+	tagConflicts         = 0x041e // 1054
+	tagConflictVersion   = 0x041f // 1055
 	tagPreinProg         = 0x043d // 1085
 	tagPostinProg        = 0x043e // 1086
 	tagPreunProg         = 0x043f // 1087
 	tagPostunProg        = 0x0440 // 1088
+	tagObsolete          = 0x0442 // 1090
 	tagFileINodes        = 0x0448 // 1096
 	tagFileLangs         = 0x0449 // 1097
 	tagProvideFlags      = 0x0458 // 1112
 	tagProvideVersion    = 0x0459 // 1113
+	tagObsoleteFlags     = 0x045a // 1114
+	tagObsoleteVersion   = 0x045b // 1115
 	tagDirindexes        = 0x045c // 1116
 	tagBasenames         = 0x045d // 1117
 	tagDirnames          = 0x045e // 1118
@@ -61,4 +76,31 @@ const (
 	tagPayloadCompressor = 0x0465 // 1125
 	tagPayloadFlags      = 0x0466 // 1126
 	tagFileDigestAlgo    = 0x1393 // 5011
+	tagRecommends        = 0x13b6 // 5046
+	tagRecommendVersion  = 0x13b7 // 5047
+	tagRecommendFlags    = 0x13b8 // 5048
+	tagSuggests          = 0x13b9 // 5049
+	tagSuggestVersion    = 0x13ba // 5050
+	tagSuggestFlags      = 0x13bb // 5051
+)
+
+type rpmSense uint32
+
+// SenseAny specifies no specific version compare
+// SenseLess specifies less then the specified version
+// SenseGreater specifies greater then the specified version
+// SenseEqual specifies equal to the specified version
+const (
+	SenseAny  rpmSense = 0
+	SenseLess rpmSense = 1 << iota
+	SenseGreater
+	SenseEqual
+)
+
+const (
+	cmpeq  = "="
+	cmpgt  = ">"
+	cmplt  = "<"
+	cmpgte = ">="
+	cmplte = "<="
 )


### PR DESCRIPTION
additional rpm field support
---
* description
* vendor
* packager
* url
* licence
* os - rpm does not read this and it defaults to linux

Package Related fields
---
* provides
* obsoletes
* suggests
* recommends
* requires
* conflicts

These fields support version comparators of ` `,  `=`, `<`, `>`, `<=`, and `>=` which will allow you to do things like
* `tar2rpm -requires 'foo>=1.0.0' -requires 'bar<1.2.4-alpha' -conflicts bla ...`