### PR TITLE
Add the payload digest

### DIFF
--- a/example_bazel/BUILD.bazel
+++ b/example_bazel/BUILD.bazel
@@ -65,6 +65,6 @@ container_image(
 docker_diff(
     name = "fedora_V",
     base = ":fedora_with_rpm",
-    cmd = "echo ===marker===  && rpm --nodigest -i /root/rpmtest.rpm && rpm -Vv rpmtest",
+    cmd = "echo ===marker===  && rpm -i /root/rpmtest.rpm && rpm -Vv rpmtest",
     golden = ":golden_V.txt",
 )

--- a/rpm.go
+++ b/rpm.go
@@ -252,6 +252,8 @@ func (r *RPM) writeGenIndexes(h *index) {
 	h.Add(tagLicence, entry(r.Licence))
 	h.Add(tagPackager, entry(r.Packager))
 	h.Add(tagURL, entry(r.URL))
+	h.Add(tagPayloadDigest, entry([]string{fmt.Sprintf("%x", sha256.Sum256(r.payload.Bytes()))}))
+	h.Add(tagPayloadDigestAlgo, entry([]int32{hashAlgoSHA256}))
 
 	// rpm utilities look for the sourcerpm tag to deduce if this is not a source rpm (if it has a sourcerpm,
 	// it is NOT a source rpm).
@@ -297,8 +299,7 @@ func (r *RPM) writeFileIndexes(h *index) {
 	for ii := range inodes {
 		// is inodes just a range from 1..len(dirindexes)? maybe different with hard links
 		inodes[ii] = int32(ii + 1)
-		// We only use the sha256 digest algo, tag=8
-		digestAlgo[ii] = int32(8)
+		digestAlgo[ii] = hashAlgoSHA256
 		// With regular files, it seems like we can always enable all of the verify flags
 		verifyFlags[ii] = int32(-1)
 		fileRDevs[ii] = int16(1)

--- a/tags.go
+++ b/tags.go
@@ -23,6 +23,9 @@ const (
 	sigSize        = 0x03e8 // 1000
 	sigPayloadSize = 0x03ef // 1007
 
+	// https://github.com/rpm-software-management/rpm/blob/92eadae94c48928bca90693ad63c46ceda37d81f/rpmio/rpmpgp.h#L258
+	hashAlgoSHA256 = 0x0008 // 8
+
 	tagName     = 0x03e8 // 1000
 	tagVersion  = 0x03e9 // 1001
 	tagRelease  = 0x03ea // 1002
@@ -81,4 +84,6 @@ const (
 	tagSuggests          = 0x13b9 // 5049
 	tagSuggestVersion    = 0x13ba // 5050
 	tagSuggestFlags      = 0x13bb // 5051
+	tagPayloadDigest     = 0x13e4 // 5092
+	tagPayloadDigestAlgo = 0x13e5 // 5093
 )


### PR DESCRIPTION
Add the payload digest so that on fedora you do not need to install the rpm with the `--nodigest` flags

Before change
```
$ rpm -Kv test.rpm
test.rpm:
    Header SHA256 digest: OK
    Payload SHA256 digest: NOTFOUND
    MD5 digest: NOTFOUND
```

After Changes
```
$ rpm -Kv test.rpm
test.rpm:
    Header SHA256 digest: OK
    Payload SHA256 digest: OK
```