### PR TITLE
Better docker testing

### DIFF
--- a/example_bazel/BUILD.bazel
+++ b/example_bazel/BUILD.bazel
@@ -5,6 +5,7 @@
 load("@io_bazel_rules_docker//container:container.bzl", "container_image")
 load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
 load("@com_github_google_rpmpack//:def.bzl", "pkg_tar2rpm")
+load("//:testing.bzl", "docker_diff")
 
 pkg_tar(
     name = "rpmtest-tar",
@@ -32,39 +33,23 @@ container_image(
     legacy_run_behavior = False,
 )
 
-container_image(
+docker_diff(
     name = "centos_V",
-    testonly = True,
     base = ":centos_with_rpm",
     cmd = "echo ===marker===  && rpm -i /root/rpmtest.rpm && rpm -Vv rpmtest",
-    legacy_run_behavior = False,
+    golden = ":golden_V.txt",
 )
 
-container_image(
+docker_diff(
     name = "centos_ls",
-    testonly = True,
     base = ":centos_with_rpm",
     cmd = "echo ===marker===  && rpm -i /root/rpmtest.rpm && ls -l /var/lib/rpmpack",
-    legacy_run_behavior = False,
+    golden = ":golden_ls.txt",
 )
 
-container_image(
+docker_diff(
     name = "centos_preinst",
-    testonly = True,
     base = ":centos_with_rpm",
     cmd = "echo ===marker===  && rpm -i /root/rpmtest.rpm && cat /tmp/preinst.txt",
-    legacy_run_behavior = False,
-)
-
-sh_test(
-    name = "docker_tests",
-    srcs = ["docker_tests.sh"],
-    data = [
-        ":centos_V",
-        ":centos_ls",
-        ":centos_preinst",
-        ":golden_V.txt",
-        ":golden_ls.txt",
-        ":golden_preinst.txt",
-    ],
+    golden = ":golden_preinst.txt",
 )

--- a/example_bazel/BUILD.bazel
+++ b/example_bazel/BUILD.bazel
@@ -53,3 +53,18 @@ docker_diff(
     cmd = "echo ===marker===  && rpm -i /root/rpmtest.rpm && cat /tmp/preinst.txt",
     golden = ":golden_preinst.txt",
 )
+
+container_image(
+    name = "fedora_with_rpm",
+    testonly = True,
+    base = "@fedora//image",
+    directory = "/root/",
+    files = [":rpmtest.rpm"],
+    legacy_run_behavior = False,
+)
+docker_diff(
+    name = "fedora_V",
+    base = ":fedora_with_rpm",
+    cmd = "echo ===marker===  && rpm --nodigest -i /root/rpmtest.rpm && rpm -Vv rpmtest",
+    golden = ":golden_V.txt",
+)

--- a/example_bazel/WORKSPACE
+++ b/example_bazel/WORKSPACE
@@ -67,3 +67,9 @@ container_pull(
     registry = "index.docker.io",
     repository = "library/centos",
 )
+container_pull(
+    name = "fedora",
+    digest = "sha256:3f3fc6a4714e44fae9147bc2b9542ac627491c13c4a3375e5066bdddc7710c9e",
+    registry = "index.docker.io",
+    repository = "library/fedora",
+)

--- a/example_bazel/diff_test.sh
+++ b/example_bazel/diff_test.sh
@@ -33,13 +33,5 @@ diff_test () {
   return 0
 }
 
-diff_test centos_V golden_V.txt
-V_result="$?"
-diff_test centos_ls golden_ls.txt
-ls_result="$?"
-diff_test centos_preinst golden_preinst.txt
-preinst_result="$?"
-
-if [[ "$V_result" -ne 0 || "$ls_result" -ne 0 || "$preinst_result" -ne 0 ]]; then
-  exit 1
-fi
+diff_test {CMD} {GOLDEN}
+exit $?

--- a/example_bazel/testing.bzl
+++ b/example_bazel/testing.bzl
@@ -1,0 +1,52 @@
+load("@io_bazel_rules_docker//container:container.bzl", "container_image")
+
+def _diff_test_impl(ctx):
+    ctx.actions.expand_template(
+        template = ctx.file._template,
+        output = ctx.outputs.file,
+        substitutions = {
+            "{CMD}": ctx.executable.cmd.short_path,
+            "{GOLDEN}": ctx.file.golden.short_path,
+        },
+    )
+
+diff_test_expand = rule(
+    attrs = {
+        "cmd": attr.label(
+            mandatory = True,
+            allow_single_file = True,
+            executable = True,
+            cfg = "host",
+        ),
+        "golden": attr.label(
+            mandatory = True,
+            allow_single_file = True,
+        ),
+        "_template": attr.label(
+            default = "//:diff_test.sh",
+            allow_single_file = True,
+        ),
+    },
+    outputs = {"file": "%{name}.sh"},
+    implementation = _diff_test_impl,
+)
+
+def docker_diff(name, base, cmd, golden):
+    container_image(
+        name = name,
+        testonly = True,
+        base = base,
+        cmd = cmd,
+        legacy_run_behavior = False,
+    )
+    diff_test_expand(
+        name = name + "_diff",
+        cmd = ":%s" % name,
+        golden = golden,
+        testonly = True,
+    )
+    native.sh_test(
+        name = name + "_diff_test",
+        srcs = [":%s_diff" % name],
+        data = [":%s" % name, golden],
+    )


### PR DESCRIPTION
1. Improve docker testing by templatizing and separating them.
    Using a bzl rule we create a test unit for each cmd.
2. Add a fedora image to the tests and see it fail without nodigest
    @djgilcrease reported in #24 that fedora installations currently fail
    without passing in nodigest. That does seems to be true. I have
    added a test case, that currently passes, but only because of the
    `--nodigest` flag. Then as part of #24 we can modify the testcase
    to omit the flag.