### PR TITLE
feat(#29): Refactor the library API to make it easier to add custom tags

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
         "sense.go",
         "tags.go",
         "tar.go",
+        "required.go"
     ],
     importpath = "github.com/google/rpmpack",
     visibility = ["//visibility:public"],

--- a/cmd/tar2rpm/main.go
+++ b/cmd/tar2rpm/main.go
@@ -33,16 +33,17 @@ var (
 	conflicts rpmpack.Relations
 	name        = flag.String("name", "", "the package name")
 	version     = flag.String("version", "", "the package version")
-	release     = flag.String("release", "", "the rpm release")
+	release     = flag.String("release", "1", "the rpm release")
 	arch        = flag.String("arch", "noarch", "the rpm architecture")
 	compressor  = flag.String("compressor", "gzip", "the rpm compressor")
 	osName      = flag.String("os", "linux", "the rpm os")
+	summary     = flag.String("summary", "", "the rpm summary")
 	description = flag.String("description", "", "the rpm description")
 	vendor      = flag.String("vendor", "", "the rpm vendor")
 	packager    = flag.String("packager", "", "the rpm packager")
-	group       = flag.String("group", "", "the rpm group")
+	group       = flag.String("group", "Development/Tools", "the rpm group")
 	url         = flag.String("url", "", "the rpm url")
-	licence     = flag.String("licence", "", "the rpm licence name")
+	licence     = flag.String("licence", "UNKNOWN", "the rpm licence name")
 
 	prein  = flag.String("prein", "", "prein scriptlet contents (not filename)")
 	postin = flag.String("postin", "", "postin scriptlet contents (not filename)")
@@ -117,6 +118,7 @@ func main() {
 			URL:         *url,
 			Licence:     *licence,
 			Description: *description,
+			Summary:     *summary,
 			Compressor:  *compressor,
 			Provides:    provides,
 			Obsoletes:   obsoletes,

--- a/file_types.go
+++ b/file_types.go
@@ -34,7 +34,7 @@ const (
 	ExcludeFile
 )
 
-// RPMFile contains a particular file's entry and data.
+// RPMFile contains a particular file's NewIndexEntry and data.
 type RPMFile struct {
 	Name  string
 	Body  []byte

--- a/header.go
+++ b/header.go
@@ -19,6 +19,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"sort"
+	"time"
 
 	"github.com/pkg/errors"
 )
@@ -78,6 +79,9 @@ func NewIndexEntry(value interface{}) (*IndexEntry, error) {
 		return intEntry(typeInt32, len(value), value)
 	case string:
 		return &IndexEntry{typeString, 1, append([]byte(value), byte(00))}, nil
+	case time.Time:
+		v := []int32{int32(value.Unix())}
+		return intEntry(typeInt32, len(v), v)
 	case []byte:
 		return &IndexEntry{typeBinary, len(value), value}, nil
 	case []string:

--- a/required.go
+++ b/required.go
@@ -1,0 +1,100 @@
+package rpmpack
+
+import (
+	"bytes"
+	"github.com/pkg/errors"
+)
+
+var (
+	ErrMissingRequiredTag = errors.New("required rpm tag is missing")
+	ErrInvalidRPMTagType  = errors.New("rpm tag is wrong type")
+)
+
+type requiredInfo struct {
+	rpmType     int
+	description string
+}
+
+var requiredTags = map[string]map[int]*requiredInfo{
+	"signatures": map[int]*requiredInfo{
+		sigSHA256:      &requiredInfo{typeString, "signature sha256"},
+		sigSize:        &requiredInfo{typeInt32, "signature size"},
+		sigPayloadSize: &requiredInfo{typeInt32, "signature payload size"},
+	},
+	"payload": map[int]*requiredInfo{
+		tagName:              &requiredInfo{typeString, "rpm name"},
+		tagSummary:           &requiredInfo{typeString, "rpm summary"},
+		tagDescription:       &requiredInfo{typeString, "rpm description"},
+		tagVersion:           &requiredInfo{typeString, "rpm version"},
+		tagRelease:           &requiredInfo{typeString, "rpm release"},
+		tagSize:              &requiredInfo{typeInt32, "rpm size"},
+		tagLicence:           &requiredInfo{typeString, "rpm licence"},
+		tagGroup:             &requiredInfo{typeString, "rpm group"},
+		tagOS:                &requiredInfo{typeString, "rpm os"},
+		tagArch:              &requiredInfo{typeString, "rpm architecture"},
+		tagPayloadFormat:     &requiredInfo{typeString, "rpm payload format"},
+		tagPayloadCompressor: &requiredInfo{typeString, "rpm payload compressor"},
+		tagPayloadFlags:      &requiredInfo{typeString, "rpm payload flags"},
+	},
+}
+
+func (r *RPM) VerifyRequiredTags() error {
+	var err error
+	if err = r.verifySignature(); err != nil {
+		return err
+	}
+	if err = r.verifyPayload(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (r *RPM) verifySignature() error {
+	var (
+		ok    bool
+		entry *IndexEntry
+	)
+
+	for tag, info := range requiredTags["signatures"] {
+		if entry, ok = r.sigIndex.entries[tag]; !ok {
+			return errors.Wrap(ErrMissingRequiredTag, info.description)
+		}
+		if err := verifyEntry(entry, info); err != nil {
+			return err
+		}
+		if tag == sigPayloadSize && !bytes.Equal(entry.data, r.payloadIndex.entries[tagSize].data) {
+			return errors.New("signature payload size does not match payload size")
+		}
+	}
+
+	return nil
+}
+
+func (r *RPM) verifyPayload() error {
+	var (
+		ok    bool
+		entry *IndexEntry
+	)
+
+	for tag, info := range requiredTags["payload"] {
+		if entry, ok = r.payloadIndex.entries[tag]; !ok {
+			return errors.Wrap(ErrMissingRequiredTag, info.description)
+		}
+		if err := verifyEntry(entry, info); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func verifyEntry(entry *IndexEntry, info *requiredInfo) error {
+	if entry.rpmtype != info.rpmType {
+		return errors.Wrapf(ErrInvalidRPMTagType, "%s got: %d expected: %d", info.description, entry.rpmtype, info.rpmType)
+	}
+	if len(entry.data) == 1 && entry.data[0] == 0 {
+		return errors.Wrapf(ErrMissingRequiredTag, "%s cannot be empty", info.description)
+	}
+
+	return nil
+}

--- a/required.go
+++ b/required.go
@@ -2,6 +2,7 @@ package rpmpack
 
 import (
 	"bytes"
+
 	"github.com/pkg/errors"
 )
 

--- a/rpm.go
+++ b/rpm.go
@@ -209,13 +209,13 @@ func (r *RPM) Write(w io.Writer) error {
 	if r.closed {
 		return ErrWriteAfterClose
 	}
-
 	if err = r.DefaultTags(); err != nil {
 		return err
 	}
 	if err = r.WriteFileIndexes(); err != nil {
 		return err
 	}
+
 	if err = r.WritePayloadIndexes(); err != nil {
 		return err
 	}
@@ -231,13 +231,6 @@ func (r *RPM) Write(w io.Writer) error {
 func (r *RPM) WriteCustom(w io.Writer) error {
 	if r.closed {
 		return ErrWriteAfterClose
-	}
-
-	if err := r.cpio.Close(); err != nil {
-		return errors.Wrap(err, "failed to close cpio payload")
-	}
-	if err := r.compressedPayload.Close(); err != nil {
-		return errors.Wrap(err, "failed to close gzip payload")
 	}
 
 	if _, err := w.Write(lead(r.Name, r.FullVersion())); err != nil {
@@ -413,6 +406,13 @@ func (r *RPM) WritePayloadIndexes() error {
 		payloadDigestAlgoEntry,
 		payloadFlagsEntry *IndexEntry
 	)
+
+	if err := r.cpio.Close(); err != nil {
+		return errors.Wrap(err, "failed to close cpio payload")
+	}
+	if err := r.compressedPayload.Close(); err != nil {
+		return errors.Wrap(err, "failed to close gzip payload")
+	}
 
 	if sizeEntry, err = NewIndexEntry([]int32{int32(r.payloadSize)}); err != nil {
 		return err

--- a/sense.go
+++ b/sense.go
@@ -75,10 +75,14 @@ func (r *Relations) addIfMissing(value *Relation) {
 // AddToIndex add the relations to the specified category on the index
 func (r *Relations) AddToIndex(h *index, nameTag, versionTag, flagsTag int) error {
 	var (
+		err      error
 		num      = len(*r)
 		names    = make([]string, num)
 		versions = make([]string, num)
 		flags    = make([]uint32, num)
+		nameEntry,
+		versionEntry,
+		flagsEntry *IndexEntry
 	)
 
 	if num == 0 {
@@ -91,9 +95,19 @@ func (r *Relations) AddToIndex(h *index, nameTag, versionTag, flagsTag int) erro
 		flags[idx] = uint32(relation.Sense)
 	}
 
-	h.Add(nameTag, entry(names))
-	h.Add(versionTag, entry(versions))
-	h.Add(flagsTag, entry(flags))
+	if nameEntry, err = NewIndexEntry(names); err != nil {
+		return err
+	}
+	if versionEntry, err = NewIndexEntry(versions); err != nil {
+		return err
+	}
+	if flagsEntry, err = NewIndexEntry(flags); err != nil {
+		return err
+	}
+
+	h.Add(nameTag, nameEntry)
+	h.Add(versionTag, versionEntry)
+	h.Add(flagsTag, flagsEntry)
 
 	return nil
 }

--- a/tags.go
+++ b/tags.go
@@ -19,24 +19,26 @@ package rpmpack
 const (
 	tagHeaderI18NTable = 0x64 // 100
 	// Signature tags are obiously overlapping regular header tags..
-	sigSHA256      = 0x0111 // 273
-	sigSize        = 0x03e8 // 1000
-	sigPayloadSize = 0x03ef // 1007
+	sigSHA256      = 0x0111 // 273  - Required
+	sigSize        = 0x03e8 // 1000  - Required
+	sigPayloadSize = 0x03ef // 1007  - Required
 
 	// https://github.com/rpm-software-management/rpm/blob/92eadae94c48928bca90693ad63c46ceda37d81f/rpmio/rpmpgp.h#L258
 	hashAlgoSHA256 = 0x0008 // 8
 
-	tagName     = 0x03e8 // 1000
-	tagVersion  = 0x03e9 // 1001
-	tagRelease  = 0x03ea // 1002
-	tagSize     = 0x03f1 // 1009
-	tagVendor   = 0x03f3 // 1011
-	tagLicence  = 0x03f6 // 1014
-	tagPackager = 0x03f7 // 1015
-	tagGroup    = 0x03f8 // 1016
-	tagURL      = 0x03fc // 1020
-	tagOS       = 0x03fd // 1021
-	tagArch     = 0x03fe // 1022
+	tagName        = 0x03e8 // 1000 - Required
+	tagVersion     = 0x03e9 // 1001 - Required
+	tagRelease     = 0x03ea // 1002 - Required
+	tagSummary     = 0x03ec // 1004 - Required
+	tagDescription = 0x03ed // 1005 - Required
+	tagSize        = 0x03f1 // 1009 - Required
+	tagVendor      = 0x03f3 // 1011
+	tagLicence     = 0x03f6 // 1014 - Required
+	tagPackager    = 0x03f7 // 1015
+	tagGroup       = 0x03f8 // 1016 - Required
+	tagURL         = 0x03fc // 1020
+	tagOS          = 0x03fd // 1021 - Required
+	tagArch        = 0x03fe // 1022 - Required
 
 	tagPrein  = 0x03ff // 1023
 	tagPostin = 0x0400 // 1024
@@ -75,9 +77,9 @@ const (
 	tagDirindexes        = 0x045c // 1116
 	tagBasenames         = 0x045d // 1117
 	tagDirnames          = 0x045e // 1118
-	tagPayloadFormat     = 0x0464 // 1124
-	tagPayloadCompressor = 0x0465 // 1125
-	tagPayloadFlags      = 0x0466 // 1126
+	tagPayloadFormat     = 0x0464 // 1124 - Required
+	tagPayloadCompressor = 0x0465 // 1125 - Required
+	tagPayloadFlags      = 0x0466 // 1126 - Required
 	tagFileDigestAlgo    = 0x1393 // 5011
 	tagRecommends        = 0x13b6 // 5046
 	tagRecommendVersion  = 0x13b7 // 5047

--- a/tags.go
+++ b/tags.go
@@ -31,6 +31,8 @@ const (
 	tagRelease     = 0x03ea // 1002 - Required
 	tagSummary     = 0x03ec // 1004 - Required
 	tagDescription = 0x03ed // 1005 - Required
+	tagBuildTime   = 0x03ee // 1006
+	tagBuildHost   = 0x03ef // 1007
 	tagSize        = 0x03f1 // 1009 - Required
 	tagVendor      = 0x03f3 // 1011
 	tagLicence     = 0x03f6 // 1014 - Required

--- a/tar_test.go
+++ b/tar_test.go
@@ -81,7 +81,7 @@ func TestFromTar(t *testing.T) {
 	for _, tc := range testCases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			r, err := FromTar(tc.input, RPMMetaData{})
+			r, err := FromTar(tc.input, RPMMetaData{Name: tc.name})
 			if err != nil {
 				t.Errorf("FromTar returned err: %v", err)
 			}

--- a/tar_test.go
+++ b/tar_test.go
@@ -67,7 +67,6 @@ func createTar(t *testing.T) io.Reader {
 }
 
 func TestFromTar(t *testing.T) {
-
 	testCases := []struct {
 		name          string
 		input         io.Reader


### PR DESCRIPTION
Refactor the library API to make it easier to add custom tags without needing to update rpmpack for every single one.

ping @jarondl 

Closes #29 
Closes goreleaser/nfpm/issues/100