### PR TITLE
Allow users to write custom index entries.

### DIFF
--- a/header_test.go
+++ b/header_test.go
@@ -71,7 +71,15 @@ func TestEntry(t *testing.T) {
 	for _, tc := range testCases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			e := entry(tc.value)
+			var e IndexEntry
+			switch v := tc.value.(type) {
+			case []string:
+				e = EntryStringSlice(v)
+			case string:
+				e = EntryString(v)
+			case []int32:
+				e = EntryInt32(v)
+			}
 			gotBytes := e.indexBytes(tc.tag, tc.offset)
 			if d := cmp.Diff(tc.wantIndexBytes, fmt.Sprintf("%x", gotBytes)); d != "" {
 				t.Errorf("entry.indexBytes() unexpected value (want->got):\n%s", d)
@@ -85,8 +93,10 @@ func TestEntry(t *testing.T) {
 
 func TestIndex(t *testing.T) {
 	i := newIndex(0x3e)
-	i.Add(0x1111, entry([]uint16{0x4444, 0x8888, 0xcccc}))
-	i.Add(0x2222, entry([]uint32{0x3333, 0x5555}))
+	i.AddEntries(map[int]IndexEntry{
+		0x1111: EntryUint16([]uint16{0x4444, 0x8888, 0xcccc}),
+		0x2222: EntryUint32([]uint32{0x3333, 0x5555}),
+	})
 	got, err := i.Bytes()
 	if err != nil {
 		t.Errorf("i.Bytes() returned error: %v", err)

--- a/rpm.go
+++ b/rpm.go
@@ -85,6 +85,8 @@ type RPM struct {
 	postin            string
 	preun             string
 	postun            string
+	customTags        map[int]IndexEntry
+	customSigs         map[int]IndexEntry
 }
 
 // NewRPM creates and returns a new RPM struct.
@@ -125,6 +127,8 @@ func NewRPM(m RPMMetaData) (*RPM, error) {
 		compressedPayload: z,
 		cpio:              cpio.NewWriter(z),
 		files:             make(map[string]RPMFile),
+		customTags:        make(map[int]IndexEntry),
+		customSigs:        make(map[int]IndexEntry),
 	}
 
 	// A package must provide itself...
@@ -179,7 +183,8 @@ func (r *RPM) Write(w io.Writer) error {
 	if err := r.writeRelationIndexes(h); err != nil {
 		return err
 	}
-
+	// CustomTags must be the last to be added, because they can overwrite values.
+	h.AddEntries(r.customTags)
 	hb, err := h.Bytes()
 	if err != nil {
 		return errors.Wrap(err, "failed to retrieve header")
@@ -187,6 +192,7 @@ func (r *RPM) Write(w io.Writer) error {
 	// Write the signatures
 	s := newIndex(signatures)
 	r.writeSignatures(s, hb)
+	s.AddEntries(r.customSigs)
 	sb, err := s.Bytes()
 	if err != nil {
 		return errors.Wrap(err, "failed to retrieve signatures header")
@@ -209,9 +215,9 @@ func (r *RPM) Write(w io.Writer) error {
 
 // Only call this after the payload and header were written.
 func (r *RPM) writeSignatures(sigHeader *index, regHeader []byte) {
-	sigHeader.Add(sigSize, entry([]int32{int32(r.payload.Len() + len(regHeader))}))
-	sigHeader.Add(sigSHA256, entry(fmt.Sprintf("%x", sha256.Sum256(regHeader))))
-	sigHeader.Add(sigPayloadSize, entry([]int32{int32(r.payloadSize)}))
+	sigHeader.Add(sigSize, EntryInt32([]int32{int32(r.payload.Len() + len(regHeader))}))
+	sigHeader.Add(sigSHA256, EntryString(fmt.Sprintf("%x", sha256.Sum256(regHeader))))
+	sigHeader.Add(sigPayloadSize, EntryInt32([]int32{int32(r.payloadSize)}))
 }
 
 func (r *RPM) writeRelationIndexes(h *index) error {
@@ -238,59 +244,69 @@ func (r *RPM) writeRelationIndexes(h *index) error {
 	return nil
 }
 
+// AddCustomTag adds or overwrites a tag value in the index.
+func (r *RPM) AddCustomTag(tag int, e IndexEntry) {
+	r.customTags[tag] = e
+}
+
+// AddCustomSig adds or overwrites a signature tag value.
+func (r *RPM) AddCustomSig(tag int, e IndexEntry) {
+	r.customSigs[tag] = e
+}
+
 func (r *RPM) writeGenIndexes(h *index) {
-	h.Add(tagHeaderI18NTable, entry("C"))
-	h.Add(tagSize, entry([]int32{int32(r.payloadSize)}))
-	h.Add(tagName, entry(r.Name))
-	h.Add(tagVersion, entry(r.Version))
-	h.Add(tagRelease, entry(r.Release))
-	h.Add(tagPayloadFormat, entry("cpio"))
-	h.Add(tagPayloadCompressor, entry(r.Compressor))
-	h.Add(tagPayloadFlags, entry("9"))
-	h.Add(tagArch, entry(r.Arch))
-	h.Add(tagOS, entry(r.OS))
-	h.Add(tagVendor, entry(r.Vendor))
-	h.Add(tagLicence, entry(r.Licence))
-	h.Add(tagPackager, entry(r.Packager))
-	h.Add(tagGroup, entry(r.Group))
-	h.Add(tagURL, entry(r.URL))
-	h.Add(tagPayloadDigest, entry([]string{fmt.Sprintf("%x", sha256.Sum256(r.payload.Bytes()))}))
-	h.Add(tagPayloadDigestAlgo, entry([]int32{hashAlgoSHA256}))
+	h.Add(tagHeaderI18NTable, EntryString("C"))
+	h.Add(tagSize, EntryInt32([]int32{int32(r.payloadSize)}))
+	h.Add(tagName, EntryString(r.Name))
+	h.Add(tagVersion, EntryString(r.Version))
+	h.Add(tagRelease, EntryString(r.Release))
+	h.Add(tagPayloadFormat, EntryString("cpio"))
+	h.Add(tagPayloadCompressor, EntryString(r.Compressor))
+	h.Add(tagPayloadFlags, EntryString("9"))
+	h.Add(tagArch, EntryString(r.Arch))
+	h.Add(tagOS, EntryString(r.OS))
+	h.Add(tagVendor, EntryString(r.Vendor))
+	h.Add(tagLicence, EntryString(r.Licence))
+	h.Add(tagPackager, EntryString(r.Packager))
+	h.Add(tagGroup, EntryString(r.Group))
+	h.Add(tagURL, EntryString(r.URL))
+	h.Add(tagPayloadDigest, EntryStringSlice([]string{fmt.Sprintf("%x", sha256.Sum256(r.payload.Bytes()))}))
+	h.Add(tagPayloadDigestAlgo, EntryInt32([]int32{hashAlgoSHA256}))
 
 	// rpm utilities look for the sourcerpm tag to deduce if this is not a source rpm (if it has a sourcerpm,
 	// it is NOT a source rpm).
-	h.Add(tagSourceRPM, entry(fmt.Sprintf("%s-%s.src.rpm", r.Name, r.FullVersion())))
+	h.Add(tagSourceRPM, EntryString(fmt.Sprintf("%s-%s.src.rpm", r.Name, r.FullVersion())))
 	if r.prein != "" {
-		h.Add(tagPrein, entry(r.prein))
-		h.Add(tagPreinProg, entry("/bin/sh"))
+		h.Add(tagPrein, EntryString(r.prein))
+		h.Add(tagPreinProg, EntryString("/bin/sh"))
 	}
 	if r.postin != "" {
-		h.Add(tagPostin, entry(r.postin))
-		h.Add(tagPostinProg, entry("/bin/sh"))
+		h.Add(tagPostin, EntryString(r.postin))
+		h.Add(tagPostinProg, EntryString("/bin/sh"))
 	}
 	if r.preun != "" {
-		h.Add(tagPreun, entry(r.preun))
-		h.Add(tagPreunProg, entry("/bin/sh"))
+		h.Add(tagPreun, EntryString(r.preun))
+		h.Add(tagPreunProg, EntryString("/bin/sh"))
 	}
 	if r.postun != "" {
-		h.Add(tagPostun, entry(r.postun))
-		h.Add(tagPostunProg, entry("/bin/sh"))
+		h.Add(tagPostun, EntryString(r.postun))
+		h.Add(tagPostunProg, EntryString("/bin/sh"))
 	}
 }
 
 // WriteFileIndexes writes file related index headers to the header
 func (r *RPM) writeFileIndexes(h *index) {
-	h.Add(tagBasenames, entry(r.basenames))
-	h.Add(tagDirindexes, entry(r.dirindexes))
-	h.Add(tagDirnames, entry(r.di.AllDirs()))
-	h.Add(tagFileSizes, entry(r.filesizes))
-	h.Add(tagFileModes, entry(r.filemodes))
-	h.Add(tagFileUserName, entry(r.fileowners))
-	h.Add(tagFileGroupName, entry(r.filegroups))
-	h.Add(tagFileMTimes, entry(r.filemtimes))
-	h.Add(tagFileDigests, entry(r.filedigests))
-	h.Add(tagFileLinkTos, entry(r.filelinktos))
-	h.Add(tagFileFlags, entry(r.fileflags))
+	h.Add(tagBasenames, EntryStringSlice(r.basenames))
+	h.Add(tagDirindexes, EntryUint32(r.dirindexes))
+	h.Add(tagDirnames, EntryStringSlice(r.di.AllDirs()))
+	h.Add(tagFileSizes, EntryUint32(r.filesizes))
+	h.Add(tagFileModes, EntryUint16(r.filemodes))
+	h.Add(tagFileUserName, EntryStringSlice(r.fileowners))
+	h.Add(tagFileGroupName, EntryStringSlice(r.filegroups))
+	h.Add(tagFileMTimes, EntryUint32(r.filemtimes))
+	h.Add(tagFileDigests, EntryStringSlice(r.filedigests))
+	h.Add(tagFileLinkTos, EntryStringSlice(r.filelinktos))
+	h.Add(tagFileFlags, EntryUint32(r.fileflags))
 
 	inodes := make([]int32, len(r.dirindexes))
 	digestAlgo := make([]int32, len(r.dirindexes))
@@ -306,11 +322,11 @@ func (r *RPM) writeFileIndexes(h *index) {
 		verifyFlags[ii] = int32(-1)
 		fileRDevs[ii] = int16(1)
 	}
-	h.Add(tagFileINodes, entry(inodes))
-	h.Add(tagFileDigestAlgo, entry(digestAlgo))
-	h.Add(tagFileVerifyFlags, entry(verifyFlags))
-	h.Add(tagFileRDevs, entry(fileRDevs))
-	h.Add(tagFileLangs, entry(fileLangs))
+	h.Add(tagFileINodes, EntryInt32(inodes))
+	h.Add(tagFileDigestAlgo, EntryInt32(digestAlgo))
+	h.Add(tagFileVerifyFlags, EntryInt32(verifyFlags))
+	h.Add(tagFileRDevs, EntryInt16(fileRDevs))
+	h.Add(tagFileLangs, EntryStringSlice(fileLangs))
 }
 
 // AddPrein adds a prein sciptlet

--- a/sense.go
+++ b/sense.go
@@ -91,9 +91,9 @@ func (r *Relations) AddToIndex(h *index, nameTag, versionTag, flagsTag int) erro
 		flags[idx] = uint32(relation.Sense)
 	}
 
-	h.Add(nameTag, entry(names))
-	h.Add(versionTag, entry(versions))
-	h.Add(flagsTag, entry(flags))
+	h.Add(nameTag, EntryStringSlice(names))
+	h.Add(versionTag, EntryStringSlice(versions))
+	h.Add(flagsTag, EntryUint32(flags))
 
 	return nil
 }


### PR DESCRIPTION
AddCustomTag and AddCustomSig Add OR OVERWRITE tags in the index or
signature. This means that a user can add a tag we don't know about,
or overwrite one we don't usually allow to change. This is a major
footgun, because users can break their rpms, but so what.

Also exposed IndexEntry, and IndexEntry creating methods, one for each
type. (yay generics :( ). This allows safe compile time checking of
input types, but does add some bookchecking for the coder.

Note that tags are saved in a separate map and added after adding our
own tags, but before serializing to bytes. That way the users can add
tags whenever they want.

Fixes #29