### PR TITLE
add pgp signing interface.

### DIFF
--- a/cmd/rpmsample/main.go
+++ b/cmd/rpmsample/main.go
@@ -66,7 +66,7 @@ func main() {
 			Owner: "root",
 			Group: "root",
 		})
-	r.AddPGPSigner(func([]byte) ([]byte, error) {
+	r.SetPGPSigner(func([]byte) ([]byte, error) {
 		return []byte(`this is not a signature`), nil
 	})
 	if err := r.Write(os.Stdout); err != nil {

--- a/cmd/rpmsample/main.go
+++ b/cmd/rpmsample/main.go
@@ -66,6 +66,9 @@ func main() {
 			Owner: "root",
 			Group: "root",
 		})
+	r.AddPGPSigner(func([]byte) ([]byte, error) {
+		return []byte(`this is not a signature`), nil
+	})
 	if err := r.Write(os.Stdout); err != nil {
 		log.Fatalf("write failed: %v", err)
 	}

--- a/example_bazel/BUILD.bazel
+++ b/example_bazel/BUILD.bazel
@@ -18,10 +18,10 @@ pkg_tar(
 pkg_tar2rpm(
     name = "rpmtest",
     data = ":rpmtest-tar",
+    epoch = 42,
     pkg_name = "rpmtest",
     prein = "echo \"This is preinst\" > /tmp/preinst.txt",
     release = "3.4",
-    epoch = 42,
     version = "1.2",
 )
 
@@ -74,6 +74,23 @@ docker_diff(
     base = ":centos_with_rpm",
     cmd = "echo ===marker===  && rpm -i /root/rpmtest.rpm && rpm -q rpmtest --queryformat '%{EPOCH}\n'",
     golden = "42",
+)
+
+container_image(
+    name = "centos_with_rpmsample_executable",
+    testonly = True,
+    base = "@centos//image",
+    directory = "/root/",
+    files = ["@com_github_google_rpmpack//cmd/rpmsample"],
+    legacy_run_behavior = False,
+)
+
+docker_diff(
+    name = "centos_rpmsample",
+    base = ":centos_with_rpmsample_executable",
+    cmd = "echo ===marker=== && /root/rpmsample > /root/rpmsample.rpm && rpm -i /root/rpmsample.rpm && rpm -q rpmsample --queryformat '%{SIGPGP}\n'",
+    # "74686973206973206e6f742061207369676e6174757265" is "this is not a signature" in hex.
+    golden = "74686973206973206e6f742061207369676e6174757265",
 )
 
 container_image(

--- a/rpm.go
+++ b/rpm.go
@@ -228,10 +228,10 @@ func (r *RPM) Write(w io.Writer) error {
 
 }
 
-// AddPGPSigner registers a function that will accept the header and payload as bytes,
+// SetPGPSigner registers a function that will accept the header and payload as bytes,
 // and return a signature as bytes. The function should simulate what gpg does,
 // probably by using golang.org/x/crypto/openpgp or by forking a gpg process.
-func (r *RPM) AddPGPSigner(f func([]byte) ([]byte, error)) {
+func (r *RPM) SetPGPSigner(f func([]byte) ([]byte, error)) {
 	r.pgpSigner = f
 }
 

--- a/tags.go
+++ b/tags.go
@@ -21,6 +21,7 @@ const (
 	// Signature tags are obiously overlapping regular header tags..
 	sigSHA256      = 0x0111 // 273
 	sigSize        = 0x03e8 // 1000
+	sigPGP         = 0x03ea // 1002
 	sigPayloadSize = 0x03ef // 1007
 
 	// https://github.com/rpm-software-management/rpm/blob/92eadae94c48928bca90693ad63c46ceda37d81f/rpmio/rpmpgp.h#L258


### PR DESCRIPTION
This allows library callers to give us a gpg signing function, which
will be used to sign the contents. The callers can create the signature
however way they want, for example by using golang's openpgp package
or by forking out to gpg. This mostly depends on managing the secret
material. If they want to use the user's keys I guess forking to gpg
is not too bad.

The test is not great: rpmsample was modified to add a signature, which
basically returns the same bytes all the time. This does not actually
validate if rpm based distros accept the key.