### PR TITLE
Handle tar filemodes that overllap with 0120000

### DIFF
--- a/rpm.go
+++ b/rpm.go
@@ -394,7 +394,7 @@ func (r *RPM) writeFile(f RPMFile) error {
 		r.filedigests = append(r.filedigests, "")
 		r.filelinktos = append(r.filelinktos, "")
 		links = 2
-	case f.Mode&0120000 != 0: //  symlink
+	case f.Mode&0120000 == 0120000: //  symlink
 		r.filesizes = append(r.filesizes, uint32(len(f.Body)))
 		r.filedigests = append(r.filedigests, "")
 		r.filelinktos = append(r.filelinktos, string(f.Body))

--- a/rpm_test.go
+++ b/rpm_test.go
@@ -8,8 +8,7 @@ import (
 func TestFileOwner(t *testing.T) {
 	r, err := NewRPM(RPMMetaData{})
 	if err != nil {
-		t.Errorf("NewRpm returned error %v", err)
-		t.FailNow()
+		t.Fatalf("NewRPM returned error %v", err)
 	}
 	group := "testGroup"
 	user := "testUser"
@@ -22,7 +21,7 @@ func TestFileOwner(t *testing.T) {
 	})
 
 	if err := r.Write(ioutil.Discard); err != nil {
-		t.Errorf("NewRpm returned error %v", err)
+		t.Errorf("NewRPM returned error %v", err)
 	}
 	if r.fileowners[0] != user {
 		t.Errorf("File owner shoud be %s but is %s", user, r.fileowners[0])
@@ -31,17 +30,18 @@ func TestFileOwner(t *testing.T) {
 		t.Errorf("File owner shoud be %s but is %s", group, r.filegroups[0])
 	}
 }
+
 // https://github.com/google/rpmpack/issues/49
 func Test100644(t *testing.T) {
 	r, err := NewRPM(RPMMetaData{})
 	if err != nil {
-		t.Errorf("NewRpm returned error %v", err)
+		t.Errorf("NewRPM returned error %v", err)
 		t.FailNow()
 	}
 	r.AddFile(RPMFile{
-		Name:  "/usr/local/hello",
-		Body:  []byte("content of the file"),
-		Mode: 0o0100644,
+		Name: "/usr/local/hello",
+		Body: []byte("content of the file"),
+		Mode: 0100644,
 	})
 
 	if err := r.Write(ioutil.Discard); err != nil {

--- a/rpm_test.go
+++ b/rpm_test.go
@@ -31,3 +31,27 @@ func TestFileOwner(t *testing.T) {
 		t.Errorf("File owner shoud be %s but is %s", group, r.filegroups[0])
 	}
 }
+// https://github.com/google/rpmpack/issues/49
+func Test100644(t *testing.T) {
+	r, err := NewRPM(RPMMetaData{})
+	if err != nil {
+		t.Errorf("NewRpm returned error %v", err)
+		t.FailNow()
+	}
+	r.AddFile(RPMFile{
+		Name:  "/usr/local/hello",
+		Body:  []byte("content of the file"),
+		Mode: 0o0100644,
+	})
+
+	if err := r.Write(ioutil.Discard); err != nil {
+		t.Errorf("Write returned error %v", err)
+	}
+	if r.filemodes[0] != 0100644 {
+		t.Errorf("file mode want 0100644, got %o", r.filemodes[0])
+	}
+	if r.filelinktos[0] != "" {
+		t.Errorf("linktos want empty (not a symlink), got %q", r.filelinktos[0])
+	}
+
+}

--- a/rpm_test.go
+++ b/rpm_test.go
@@ -35,8 +35,7 @@ func TestFileOwner(t *testing.T) {
 func Test100644(t *testing.T) {
 	r, err := NewRPM(RPMMetaData{})
 	if err != nil {
-		t.Errorf("NewRPM returned error %v", err)
-		t.FailNow()
+		t.Fatalf("NewRPM returned error %v", err)
 	}
 	r.AddFile(RPMFile{
 		Name: "/usr/local/hello",


### PR DESCRIPTION
We had bad logic to deduce symlinks. This caused us to think
files with modes such as 0100644 are symlinks. All this change
does is properly compare the bits.

Fixes #49