### PR TITLE
Handle GhostFiles correctly, by adding them to the rpm structures but…

### DIFF
--- a/cmd/rpmsample/main.go
+++ b/cmd/rpmsample/main.go
@@ -66,6 +66,14 @@ func main() {
 			Owner: "root",
 			Group: "root",
 		})
+	r.AddFile(
+		rpmpack.RPMFile{
+			Name:  "/var/lib/rpmpack/sample4_ghost.txt",
+			Mode:  0644,
+			Owner: "root",
+			Group: "root",
+			Type:  rpmpack.GhostFile,
+		})
 	r.SetPGPSigner(func([]byte) ([]byte, error) {
 		return []byte(`this is not a signature`), nil
 	})

--- a/example_bazel/BUILD.bazel
+++ b/example_bazel/BUILD.bazel
@@ -93,6 +93,24 @@ docker_diff(
     golden = "74686973206973206e6f742061207369676e6174757265",
 )
 
+docker_diff(
+    name = "centos_rpmsample_ghost_provides",
+    base = ":centos_with_rpmsample_executable",
+    cmd = "echo ===marker=== && /root/rpmsample > /root/rpmsample.rpm && rpm -i /root/rpmsample.rpm && rpm -q --whatprovides /var/lib/rpmpack/sample4_ghost.txt",
+    golden = "rpmsample-0.1-A.noarch",
+)
+
+docker_diff(
+    name = "centos_rpmsample_ghost_not_on_fs",
+    base = ":centos_with_rpmsample_executable",
+    cmd = "echo ===marker=== && /root/rpmsample > /root/rpmsample.rpm && rpm -i /root/rpmsample.rpm && ls /var/lib/rpmpack",
+    golden = """
+sample.txt
+sample2.txt
+sample3_link.txt
+""",
+)
+
 container_image(
     name = "fedora_with_rpm",
     testonly = True,

--- a/rpm.go
+++ b/rpm.go
@@ -426,6 +426,11 @@ func (r *RPM) writeFile(f RPMFile) error {
 		r.filelinktos = append(r.filelinktos, "")
 	}
 	r.filemodes = append(r.filemodes, uint16(f.Mode))
+
+	// Ghost files have no payload
+	if f.Type == GhostFile {
+		return nil
+	}
 	return r.writePayload(f, links)
 }
 


### PR DESCRIPTION
… not the cpio

GhostFiles should have no written payload, but we wrote empty ghost files instead. This fixes the problem.

Fixes #51 