### PR TITLE
fix: ensure the rpm signature is properly validated

### DIFF
--- a/tags.go
+++ b/tags.go
@@ -19,6 +19,7 @@ package rpmpack
 const (
 	tagHeaderI18NTable = 0x64 // 100
 	// Signature tags are obiously overlapping regular header tags..
+	sigRSA         = 0x010c // 256
 	sigSHA256      = 0x0111 // 273
 	sigSize        = 0x03e8 // 1000
 	sigPGP         = 0x03ea // 1002


### PR DESCRIPTION
fixes: https://github.com/goreleaser/nfpm/issues/265

It looks like yum & dnf try to verify the header signature as well even if it is not signed when pulling the rpm from a repo, but not when it is a local file.