### PR TITLE
Fix tests by conditionally signing.

### DIFF
--- a/cmd/rpmsample/main.go
+++ b/cmd/rpmsample/main.go
@@ -18,6 +18,7 @@
 package main
 
 import (
+	"flag"
 	"log"
 	"os"
 
@@ -25,6 +26,9 @@ import (
 )
 
 func main() {
+
+	sign := flag.Bool("sign", false, "sign the package with a fake sig")
+	flag.Parse()
 
 	r, err := rpmpack.NewRPM(rpmpack.RPMMetaData{
 		Name:    "rpmsample",
@@ -74,9 +78,11 @@ func main() {
 			Group: "root",
 			Type:  rpmpack.GhostFile,
 		})
-	r.SetPGPSigner(func([]byte) ([]byte, error) {
-		return []byte(`this is not a signature`), nil
-	})
+	if *sign {
+		r.SetPGPSigner(func([]byte) ([]byte, error) {
+			return []byte(`this is not a signature`), nil
+		})
+	}
 	if err := r.Write(os.Stdout); err != nil {
 		log.Fatalf("write failed: %v", err)
 	}

--- a/example_bazel/BUILD.bazel
+++ b/example_bazel/BUILD.bazel
@@ -27,10 +27,10 @@ pkg_tar2rpm(
 
 pkg_tar2rpm(
     name = "rpmtest_withtime",
+    build_time = "17",
     data = ":rpmtest-tar",
     pkg_name = "rpmtest_withtime",
     version = "1.2",
-    build_time = "17",
 )
 
 container_image(
@@ -38,7 +38,10 @@ container_image(
     testonly = True,
     base = "@centos//image",
     directory = "/root/",
-    files = [":rpmtest.rpm", ":rpmtest_withtime"],
+    files = [
+        ":rpmtest.rpm",
+        ":rpmtest_withtime",
+    ],
     legacy_run_behavior = False,
 )
 
@@ -86,9 +89,9 @@ container_image(
 )
 
 docker_diff(
-    name = "centos_rpmsample",
+    name = "centos_rpmsample_signed",
     base = ":centos_with_rpmsample_executable",
-    cmd = "echo ===marker=== && /root/rpmsample > /root/rpmsample.rpm && rpm -i /root/rpmsample.rpm && rpm -q rpmsample --queryformat '%{SIGPGP}\n'",
+    cmd = "echo ===marker=== && /root/rpmsample -sign > /root/rpmsample.rpm && rpm --nosignature -i /root/rpmsample.rpm && rpm --nosignature -q rpmsample --queryformat '%{SIGPGP}\n'",
     # "74686973206973206e6f742061207369676e6174757265" is "this is not a signature" in hex.
     golden = "74686973206973206e6f742061207369676e6174757265",
 )
@@ -145,11 +148,11 @@ pkg_tar(
 pkg_tar2rpm(
     name = "rpmmetatest",
     data = ":rpmmetatest-tar",
+    epoch = 42,
     pkg_name = "rpmmetatest",
     release = "3.4",
-    epoch = 42,
-    version = "1.2",
     requires = ["bash"],
+    version = "1.2",
 )
 
 container_image(


### PR DESCRIPTION
Since #53 our tests are broken, because centos refuses to work with an unverifyable signed header. So we add a flag to sign only in the relevant test, and there use the nosignature flag to avoid centos trying to validate the signature.

This is another reminder that we must fix out CI testing soon.