### PR TITLE
Make repo compatible with --incompatible_disallow_empty_glob

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -39,7 +39,6 @@ go_test(
         "sense_test.go",
         "tar_test.go",
     ],
-    data = glob(["testdata/**"]),
     embed = [":go_default_library"],
     deps = ["@com_github_google_go_cmp//cmp:go_default_library"],
 )


### PR DESCRIPTION
This make the repo compatible with --incompatible_disallow_empty_glob

Discovered while using bazelisk `--migrate` option.