### PR TITLE
update Bazel build with new naming convention

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -6,10 +6,11 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 load("@bazel_gazelle//:def.bzl", "gazelle")
 
 # gazelle:prefix github.com/google/rpmpack
+# gazelle:go_naming_convention import_alias
 gazelle(name = "gazelle")
 
 go_library(
-    name = "go_default_library",
+    name = "rpmpack",
     srcs = [
         "dir.go",
         "file_types.go",
@@ -30,7 +31,7 @@ go_library(
 )
 
 go_test(
-    name = "go_default_test",
+    name = "rpmpack_test",
     srcs = [
         "dir_test.go",
         "file_types_test.go",
@@ -39,6 +40,12 @@ go_test(
         "sense_test.go",
         "tar_test.go",
     ],
-    embed = [":go_default_library"],
+    embed = [":rpmpack"],
     deps = ["@com_github_google_go_cmp//cmp:go_default_library"],
+)
+
+alias(
+    name = "go_default_library",
+    actual = ":rpmpack",
+    visibility = ["//visibility:public"],
 )

--- a/README.md
+++ b/README.md
@@ -70,15 +70,31 @@ git_repository(
 
 # The following will load the requirements to build rpmpack
 http_archive(
-      name = "io_bazel_rules_go",
-      sha256 = "ae8c36ff6e565f674c7a3692d6a9ea1096e4c1ade497272c2108a810fb39acd2",
-      urls = ["https://github.com/bazelbuild/rules_go/releases/download/0.19.4/rules_go-0.19.4.tar.gz"],
-  )
+    name = "io_bazel_rules_go",
+    sha256 = "69de5c704a05ff37862f7e0f5534d4f479418afc21806c887db544a316f3cb6b",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.27.0/rules_go-v0.27.0.tar.gz",
+        "https://github.com/bazelbuild/rules_go/releases/download/v0.27.0/rules_go-v0.27.0.tar.gz",
+    ],
+)
+
 http_archive(
-      name = "bazel_gazelle",
-      sha256 = "7fc87f4170011201b1690326e8c16c5d802836e3a0d617d8f75c3af2b23180c4",
-      urls = ["https://github.com/bazelbuild/bazel-gazelle/releases/download/0.18.2/bazel-gazelle-0.18.2.tar.gz"],
-  )
+    name = "bazel_gazelle",
+    sha256 = "62ca106be173579c0a167deb23358fdfe71ffa1e4cfdddf5582af26520f1c66f",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/bazel-gazelle/releases/download/v0.23.0/bazel-gazelle-v0.23.0.tar.gz",
+        "https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.23.0/bazel-gazelle-v0.23.0.tar.gz",
+    ],
+)
+
+load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
+load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
+
+go_rules_dependencies()
+
+go_register_toolchains(version = "1.16")
+
+gazelle_dependencies()
 
 load("@com_github_google_rpmpack//:deps.bzl", "rpmpack_dependencies")
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -4,15 +4,30 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "io_bazel_rules_go",
-    sha256 = "ae8c36ff6e565f674c7a3692d6a9ea1096e4c1ade497272c2108a810fb39acd2",
-    urls = ["https://github.com/bazelbuild/rules_go/releases/download/0.19.4/rules_go-0.19.4.tar.gz"],
+    sha256 = "69de5c704a05ff37862f7e0f5534d4f479418afc21806c887db544a316f3cb6b",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.27.0/rules_go-v0.27.0.tar.gz",
+        "https://github.com/bazelbuild/rules_go/releases/download/v0.27.0/rules_go-v0.27.0.tar.gz",
+    ],
 )
 
 http_archive(
     name = "bazel_gazelle",
-    sha256 = "7fc87f4170011201b1690326e8c16c5d802836e3a0d617d8f75c3af2b23180c4",
-    urls = ["https://github.com/bazelbuild/bazel-gazelle/releases/download/0.18.2/bazel-gazelle-0.18.2.tar.gz"],
+    sha256 = "62ca106be173579c0a167deb23358fdfe71ffa1e4cfdddf5582af26520f1c66f",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/bazel-gazelle/releases/download/v0.23.0/bazel-gazelle-v0.23.0.tar.gz",
+        "https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.23.0/bazel-gazelle-v0.23.0.tar.gz",
+    ],
 )
+
+load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
+load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
+
+go_rules_dependencies()
+
+go_register_toolchains(version = "1.16")
+
+gazelle_dependencies()
 
 load("//:deps.bzl", "rpmpack_dependencies")
 

--- a/cmd/rpmsample/BUILD.bazel
+++ b/cmd/rpmsample/BUILD.bazel
@@ -1,15 +1,15 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 
 go_library(
-    name = "go_default_library",
+    name = "rpmsample_lib",
     srcs = ["main.go"],
     importpath = "github.com/google/rpmpack/cmd/rpmsample",
     visibility = ["//visibility:private"],
-    deps = ["//:go_default_library"],
+    deps = ["//:rpmpack"],
 )
 
 go_binary(
     name = "rpmsample",
-    embed = [":go_default_library"],
+    embed = [":rpmsample_lib"],
     visibility = ["//visibility:public"],
 )

--- a/cmd/tar2rpm/BUILD.bazel
+++ b/cmd/tar2rpm/BUILD.bazel
@@ -1,15 +1,15 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 
 go_library(
-    name = "go_default_library",
+    name = "tar2rpm_lib",
     srcs = ["main.go"],
     importpath = "github.com/google/rpmpack/cmd/tar2rpm",
     visibility = ["//visibility:private"],
-    deps = ["//:go_default_library"],
+    deps = ["//:rpmpack"],
 )
 
 go_binary(
     name = "tar2rpm",
-    embed = [":go_default_library"],
+    embed = [":tar2rpm_lib"],
     visibility = ["//visibility:public"],
 )

--- a/example_bazel/WORKSPACE
+++ b/example_bazel/WORKSPACE
@@ -19,15 +19,30 @@ local_repository(
 # The following will load the requirements to build rpmpack
 http_archive(
     name = "io_bazel_rules_go",
-    sha256 = "ae8c36ff6e565f674c7a3692d6a9ea1096e4c1ade497272c2108a810fb39acd2",
-    urls = ["https://github.com/bazelbuild/rules_go/releases/download/0.19.4/rules_go-0.19.4.tar.gz"],
+    sha256 = "69de5c704a05ff37862f7e0f5534d4f479418afc21806c887db544a316f3cb6b",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.27.0/rules_go-v0.27.0.tar.gz",
+        "https://github.com/bazelbuild/rules_go/releases/download/v0.27.0/rules_go-v0.27.0.tar.gz",
+    ],
 )
 
 http_archive(
     name = "bazel_gazelle",
-    sha256 = "7fc87f4170011201b1690326e8c16c5d802836e3a0d617d8f75c3af2b23180c4",
-    urls = ["https://github.com/bazelbuild/bazel-gazelle/releases/download/0.18.2/bazel-gazelle-0.18.2.tar.gz"],
+    sha256 = "62ca106be173579c0a167deb23358fdfe71ffa1e4cfdddf5582af26520f1c66f",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/bazel-gazelle/releases/download/v0.23.0/bazel-gazelle-v0.23.0.tar.gz",
+        "https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.23.0/bazel-gazelle-v0.23.0.tar.gz",
+    ],
 )
+
+load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
+load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
+
+go_rules_dependencies()
+
+go_register_toolchains(version = "1.16")
+
+gazelle_dependencies()
 
 load("@com_github_google_rpmpack//:deps.bzl", "rpmpack_dependencies")
 


### PR DESCRIPTION
By default, [Gazelle now uses](https://github.com/bazelbuild/bazel-gazelle/issues/982#issuecomment-758105572) the last component of the Bazel package, rather than `go_default_library` as the `go_library` name.  This causes problems when the naming conventions do not match.

Adding support for the new naming convention should not break anything that depends on using the old naming convention, because the setting the Gazelle directive `go_naming_convention` to `import_alias` makes aliases to the libraries and this allows the old naming convention to still work.

The version of Gazelle and rules_go is also updated.