### PR TITLE
feat: zstd compression and compressor levels

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -27,6 +27,7 @@ go_library(
         "@com_github_pkg_errors//:go_default_library",
         "@com_github_ulikunitz_xz//:go_default_library",
         "@com_github_ulikunitz_xz//lzma:go_default_library",
+        "@com_github_klauspost_compress//zstd:go_default_library",
     ],
 )
 

--- a/deps.bzl
+++ b/deps.bzl
@@ -33,3 +33,10 @@ def rpmpack_dependencies():
         sum = "h1:YvTNdFzX6+W5m9msiYg/zpkSURPPtOlzbqYjrFn7Yt4=",
         version = "v0.5.7",
     )
+
+    go_repository(
+        name = "com_github_klauspost_compress",
+        importpath = "github.com/klauspost/compress",
+        sum = "h1:P76CopJELS0TiO2mebmnzgWaajssP/EszplttgQxcgc=",
+        version = "v1.13.6",
+    )

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.12
 require (
 	github.com/cavaliercoder/go-cpio v0.0.0-20180626203310-925f9528c45e
 	github.com/google/go-cmp v0.3.1
+	github.com/klauspost/compress v1.13.6
 	github.com/pkg/errors v0.9.1
 	github.com/ulikunitz/xz v0.5.8
 )

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/cavaliercoder/go-cpio v0.0.0-20180626203310-925f9528c45e h1:hHg27A0RS
 github.com/cavaliercoder/go-cpio v0.0.0-20180626203310-925f9528c45e/go.mod h1:oDpT4efm8tSYHXV5tHSdRvBet/b/QzxZ+XyyPehvm3A=
 github.com/google/go-cmp v0.3.1 h1:Xye71clBPdm5HgqGwUkwhbynsUJZhDbS20FvLhQ2izg=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
+github.com/klauspost/compress v1.13.6 h1:P76CopJELS0TiO2mebmnzgWaajssP/EszplttgQxcgc=
+github.com/klauspost/compress v1.13.6/go.mod h1:/3/Vjq9QcHkK5uEr5lBEmyoZ1iFhe47etQ6QUkpK6sk=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/ulikunitz/xz v0.5.8 h1:ERv8V6GKqVi23rgu5cj9pVfVzJbOqAY2Ntl88O6c2nQ=

--- a/rpm.go
+++ b/rpm.go
@@ -192,9 +192,13 @@ func setupCompressor(compressorSetting string, w io.Writer) (wc io.WriteCloser,
 		if compressorLevel != "" {
 			var ok bool
 
-			ok, level = zstd.EncoderLevelFromString(compressorLevel)
-			if !ok {
-				return nil, "", fmt.Errorf("invalid zstd compressor level: %s", compressorLevel)
+			if intLevel, err := strconv.Atoi(compressorLevel); err == nil {
+				level = zstd.EncoderLevelFromZstd(intLevel)
+			} else {
+				ok, level = zstd.EncoderLevelFromString(compressorLevel)
+				if !ok {
+					return nil, "", fmt.Errorf("invalid zstd compressor level: %s", compressorLevel)
+				}
 			}
 		}
 

--- a/rpm_test.go
+++ b/rpm_test.go
@@ -104,13 +104,13 @@ func TestCompression(t *testing.T) {
 			Type: "zstd",
 			Compressors: []string{
 				"zstd", "zstd:fastest", "zstd:default", "zstd:better",
-				"zstd:best", "zstd:BeSt",
+				"zstd:best", "zstd:BeSt", "zstd:0", "zstd:4", "zstd:8", "zstd:15",
 			},
 			ExpectedWriter: &zstd.Encoder{},
 		},
 		{
 			Type:           "zstd",
-			Compressors:    []string{"zstd:1", "xz:worst"},
+			Compressors:    []string{"xz:worst"},
 			ExpectedWriter: nil, // zstd does not support integer compression level
 		},
 	}

--- a/rpm_test.go
+++ b/rpm_test.go
@@ -111,7 +111,7 @@ func TestCompression(t *testing.T) {
 		{
 			Type:           "zstd",
 			Compressors:    []string{"xz:worst"},
-			ExpectedWriter: nil, // zstd does not support integer compression level
+			ExpectedWriter: nil, // only integers levels or one of the pre-defined string values
 		},
 	}
 

--- a/rpm_test.go
+++ b/rpm_test.go
@@ -1,8 +1,15 @@
 package rpmpack
 
 import (
+	"compress/gzip"
+	"io"
 	"io/ioutil"
+	"reflect"
 	"testing"
+
+	"github.com/klauspost/compress/zstd"
+	"github.com/ulikunitz/xz"
+	"github.com/ulikunitz/xz/lzma"
 )
 
 func TestFileOwner(t *testing.T) {
@@ -52,5 +59,83 @@ func Test100644(t *testing.T) {
 	if r.filelinktos[0] != "" {
 		t.Errorf("linktos want empty (not a symlink), got %q", r.filelinktos[0])
 	}
+}
 
+func TestCompression(t *testing.T) {
+	testCases := []struct {
+		Compressors    []string
+		ExpectedWriter io.Writer
+	}{
+		{
+			Compressors: []string{
+				"", "gzip", "gzip:1", "gzip:2", "gzip:3",
+				"gzip:4", "gzip:5", "gzip:6", "gzip:7", "gzip:8", "gzip:9",
+			},
+			ExpectedWriter: &gzip.Writer{},
+		},
+		{
+			Compressors:    []string{"gzip:fast", "gzip:10"},
+			ExpectedWriter: nil, // gzip requires an integer level from -2 to 9
+		},
+		{
+			Compressors:    []string{"lzma"},
+			ExpectedWriter: &lzma.Writer{},
+		},
+		{
+			Compressors:    []string{"lzma:fast", "lzma:1"},
+			ExpectedWriter: nil, // lzma does not support specifying the compression level
+		},
+		{
+			Compressors:    []string{"xz"},
+			ExpectedWriter: &xz.Writer{},
+		},
+		{
+			Compressors:    []string{"xz:fast", "xz:1"},
+			ExpectedWriter: nil, // xz does not support specifying the compression level
+		},
+		{
+			Compressors: []string{
+				"zstd", "zstd:fastest", "zstd:default", "zstd:better",
+				"zstd:best", "zstd:BeSt",
+			},
+			ExpectedWriter: &zstd.Encoder{},
+		},
+		{
+			Compressors:    []string{"zstd:1", "xz:worst"},
+			ExpectedWriter: nil, // zstd does not support integer compression level
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+
+		for _, compressor := range testCase.Compressors {
+			t.Run(compressor, func(t *testing.T) {
+				r, err := NewRPM(RPMMetaData{
+					Compressor: compressor,
+				})
+				if err != nil {
+					if testCase.ExpectedWriter == nil {
+						return // an error is expected
+					}
+
+					t.Fatalf("NewRPM returned error %v", err)
+				}
+
+				if testCase.ExpectedWriter == nil {
+					t.Fatalf("compressor %q should have produced an error", compressor)
+				}
+
+				expectedWriterType := reflect.Indirect(reflect.ValueOf(
+					testCase.ExpectedWriter)).String()
+				actualWriterType := reflect.Indirect(reflect.ValueOf(
+					r.compressedPayload)).String()
+
+				if expectedWriterType != actualWriterType {
+					t.Fatalf("expected writer to be %T, got %T instead",
+						testCase.ExpectedWriter, r.compressedPayload)
+				}
+			})
+		}
+	}
 }

--- a/rpm_test.go
+++ b/rpm_test.go
@@ -63,10 +63,12 @@ func Test100644(t *testing.T) {
 
 func TestCompression(t *testing.T) {
 	testCases := []struct {
+		Type           string
 		Compressors    []string
 		ExpectedWriter io.Writer
 	}{
 		{
+			Type: "gzip",
 			Compressors: []string{
 				"", "gzip", "gzip:1", "gzip:2", "gzip:3",
 				"gzip:4", "gzip:5", "gzip:6", "gzip:7", "gzip:8", "gzip:9",
@@ -74,26 +76,32 @@ func TestCompression(t *testing.T) {
 			ExpectedWriter: &gzip.Writer{},
 		},
 		{
+			Type:           "gzip",
 			Compressors:    []string{"gzip:fast", "gzip:10"},
 			ExpectedWriter: nil, // gzip requires an integer level from -2 to 9
 		},
 		{
+			Type:           "lzma",
 			Compressors:    []string{"lzma"},
 			ExpectedWriter: &lzma.Writer{},
 		},
 		{
+			Type:           "lzma",
 			Compressors:    []string{"lzma:fast", "lzma:1"},
 			ExpectedWriter: nil, // lzma does not support specifying the compression level
 		},
 		{
+			Type:           "xz",
 			Compressors:    []string{"xz"},
 			ExpectedWriter: &xz.Writer{},
 		},
 		{
+			Type:           "xz",
 			Compressors:    []string{"xz:fast", "xz:1"},
 			ExpectedWriter: nil, // xz does not support specifying the compression level
 		},
 		{
+			Type: "zstd",
 			Compressors: []string{
 				"zstd", "zstd:fastest", "zstd:default", "zstd:better",
 				"zstd:best", "zstd:BeSt",
@@ -101,6 +109,7 @@ func TestCompression(t *testing.T) {
 			ExpectedWriter: &zstd.Encoder{},
 		},
 		{
+			Type:           "zstd",
 			Compressors:    []string{"zstd:1", "xz:worst"},
 			ExpectedWriter: nil, // zstd does not support integer compression level
 		},
@@ -124,6 +133,11 @@ func TestCompression(t *testing.T) {
 
 				if testCase.ExpectedWriter == nil {
 					t.Fatalf("compressor %q should have produced an error", compressor)
+				}
+
+				if r.RPMMetaData.Compressor != testCase.Type {
+					t.Fatalf("expected compressor %q, got %q", compressor,
+						r.RPMMetaData.Compressor)
 				}
 
 				expectedWriterType := reflect.Indirect(reflect.ValueOf(


### PR DESCRIPTION
This PR closes #66 by adding support for `zstd` compression. It also allows users to optionally specify the compression level for `gzip` (`gzip:-2` up to `gzip:9`) and `zstd` (`zstd:default`, `zstd:fastest`, `zstd:better`, `zstd:best`, `zstd:17`). It also contains a test for the compression configuration.

I can also add `bzip2` such that this PR can supersede #67 if you want.