### PR TITLE
Allowlist for directories

### DIFF
--- a/cmd/rpmsample/main.go
+++ b/cmd/rpmsample/main.go
@@ -78,6 +78,14 @@ func main() {
 			Group: "root",
 			Type:  rpmpack.GhostFile,
 		})
+	r.AddFile(
+		rpmpack.RPMFile{
+			Name:  "/var/lib/thisdoesnotexist/sample.txt",
+			Mode:  0644,
+			Body:  []byte("testsample\n"),
+			Owner: "root",
+			Group: "root",
+		})
 	if *sign {
 		r.SetPGPSigner(func([]byte) ([]byte, error) {
 			return []byte(`this is not a signature`), nil

--- a/cmd/tar2rpm/main.go
+++ b/cmd/tar2rpm/main.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"bufio"
 	"flag"
 	"fmt"
 	"io"
@@ -53,6 +54,9 @@ var (
 	postin = flag.String("postin", "", "postin scriptlet contents (not filename)")
 	preun  = flag.String("preun", "", "preun scriptlet contents (not filename)")
 	postun = flag.String("postun", "", "postun scriptlet contents (not filename)")
+
+	useDirAllowlist = flag.Bool("use_dir_allowlist", false, "Only include dirs in the explicit allow list")
+	dirAllowlist    = flag.String("dir_allowlist", "", "A file with one directory per line to include from the tar to the rpm")
 
 	outputfile = flag.String("file", "", "write rpm to `FILE` instead of stdout")
 )
@@ -142,15 +146,32 @@ func main() {
 			Requires:    requires,
 			Conflicts:   conflicts,
 		})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "tar2rpm error: %v\n", err)
+		os.Exit(1)
+	}
+	if *useDirAllowlist {
+		al := map[string]bool{}
+		if *dirAllowlist != "" {
+			f, err := os.Open(*dirAllowlist)
+			if err != nil {
+				log.Fatalf("Failed to open dir allowlist %q for reading\n: %s", *dirAllowlist, err)
+			}
+			defer f.Close()
+			scan := bufio.NewScanner(f)
+			for scan.Scan() {
+				t := scan.Text()
+				al[t] = true
+			}
+		}
+		r.AllowListDirs(al)
+	}
+
 	r.AddPrein(*prein)
 	r.AddPostin(*postin)
 	r.AddPreun(*preun)
 	r.AddPostun(*postun)
 
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "tar2rpm error: %v\n", err)
-		os.Exit(1)
-	}
 	if err := r.Write(w); err != nil {
 		fmt.Fprintf(os.Stderr, "rpm write error: %v\n", err)
 		os.Exit(1)

--- a/cmd/tar2rpm/main.go
+++ b/cmd/tar2rpm/main.go
@@ -55,8 +55,8 @@ var (
 	preun  = flag.String("preun", "", "preun scriptlet contents (not filename)")
 	postun = flag.String("postun", "", "postun scriptlet contents (not filename)")
 
-	useDirAllowlist = flag.Bool("use_dir_allowlist", false, "Only include dirs in the explicit allow list")
-	dirAllowlist    = flag.String("dir_allowlist", "", "A file with one directory per line to include from the tar to the rpm")
+	useDirAllowlist  = flag.Bool("use_dir_allowlist", false, "Only include dirs in the explicit allow list")
+	dirAllowlistFile = flag.String("dir_allowlist_file", "", "A file with one directory per line to include from the tar to the rpm")
 
 	outputfile = flag.String("file", "", "write rpm to `FILE` instead of stdout")
 )
@@ -152,10 +152,10 @@ func main() {
 	}
 	if *useDirAllowlist {
 		al := map[string]bool{}
-		if *dirAllowlist != "" {
-			f, err := os.Open(*dirAllowlist)
+		if *dirAllowlistFile != "" {
+			f, err := os.Open(*dirAllowlistFile)
 			if err != nil {
-				log.Fatalf("Failed to open dir allowlist %q for reading\n: %s", *dirAllowlist, err)
+				log.Fatalf("Failed to open dir allowlist %q for reading\n: %s", *dirAllowlistFile, err)
 			}
 			defer f.Close()
 			scan := bufio.NewScanner(f)

--- a/def.bzl
+++ b/def.bzl
@@ -16,9 +16,9 @@ def _pkg_tar2rpm_impl(ctx):
         args.add("--build_time", ctx.attr.build_time)
     if ctx.attr.use_dir_allowlist:
         args.add("--use_dir_allowlist")
-    if ctx.file.dir_allowlist:
-        args.add("--dir_allowlist", ctx.file.dir_allowlist)
-        files.append(ctx.file.dir_allowlist)
+    if ctx.file.dir_allowlist_file:
+        args.add("--dir_allowlist_file", ctx.file.dir_allowlist_file)
+        files.append(ctx.file.dir_allowlist_file)
     args.add("--file", ctx.outputs.out)
     args.add(ctx.file.data)
     ctx.actions.run(
@@ -48,7 +48,7 @@ pkg_tar2rpm = rule(
         "build_time": attr.string(),
         "use_dir_allowlist": attr.bool(default = False, doc = """Only include
 directories themselves if they are in the allowlist file. Using this without an allowlist means do not include directories at all, only files."""),
-        "dir_allowlist": attr.label(allow_single_file = True, doc = "A file with a list of directories to include in the rpm. The files contained in the directories are always added."),
+        "dir_allowlist_file": attr.label(allow_single_file = True, doc = "A file with a list of directories to include in the rpm. The files contained in the directories are always added."),
         "tar2rpm": attr.label(
             default = Label("//cmd/tar2rpm"),
             cfg = "host",

--- a/def.bzl
+++ b/def.bzl
@@ -14,6 +14,11 @@ def _pkg_tar2rpm_impl(ctx):
     args.add_all("--requires", ctx.attr.requires)
     if ctx.attr.build_time != "":
         args.add("--build_time", ctx.attr.build_time)
+    if ctx.attr.use_dir_allowlist:
+        args.add("--use_dir_allowlist")
+    if ctx.file.dir_allowlist:
+        args.add("--dir_allowlist", ctx.file.dir_allowlist)
+        files.append(ctx.file.dir_allowlist)
     args.add("--file", ctx.outputs.out)
     args.add(ctx.file.data)
     ctx.actions.run(
@@ -41,6 +46,9 @@ pkg_tar2rpm = rule(
         "postun": attr.string(),
         "requires": attr.string_list(),
         "build_time": attr.string(),
+        "use_dir_allowlist": attr.bool(default = False, doc = """Only include
+directories themselves if they are in the allowlist file. Using this without an allowlist means do not include directories at all, only files."""),
+        "dir_allowlist": attr.label(allow_single_file = True, doc = "A file with a list of directories to include in the rpm. The files contained in the directories are always added."),
         "tar2rpm": attr.label(
             default = Label("//cmd/tar2rpm"),
             cfg = "host",

--- a/example_bazel/BUILD.bazel
+++ b/example_bazel/BUILD.bazel
@@ -246,11 +246,10 @@ docker_diff(
     base = ":centos_with_rpm",
     cmd = "echo ===marker===  && rpm -i --force /root/rpmtest_bothdirs.rpm && rpm -Vv rpmtest_bothdirs",
     golden = """
-.........    /does
-.........    /does/not
-.........    /does/not/exist
-.........    /does/not/exist/rpmpack
-.........    /does/not/exist/rpmpack/content1.txt
+.........    /doesnot
+.........    /doesnot/exist
+.........    /doesnot/exist/rpmpack
+.........    /doesnot/exist/rpmpack/content1.txt
 .........    /var
 .........    /var/lib
 .........    /var/lib/rpmpack
@@ -262,7 +261,7 @@ docker_diff(
     base = ":centos_with_rpm",
     cmd = "echo ===marker===  && rpm -i /root/rpmtest_withoutbothdirs.rpm && rpm -Vv rpmtest_withoutbothdirs",
     golden = """
-.........    /does/not/exist/rpmpack/content1.txt
+.........    /doesnot/exist/rpmpack/content1.txt
 .........    /var/lib/rpmpack/content1.txt""",
 )
 
@@ -271,8 +270,8 @@ docker_diff(
     base = ":centos_with_rpm",
     cmd = "echo ===marker===  && rpm -i /root/rpmtest_withonlyonedir.rpm && rpm -Vv rpmtest_withonlyonedir",
     golden = """
-.........    /does/not/exist
-.........    /does/not/exist/rpmpack
-.........    /does/not/exist/rpmpack/content1.txt
+.........    /doesnot/exist
+.........    /doesnot/exist/rpmpack
+.........    /doesnot/exist/rpmpack/content1.txt
 .........    /var/lib/rpmpack/content1.txt""",
 )

--- a/example_bazel/BUILD.bazel
+++ b/example_bazel/BUILD.bazel
@@ -71,7 +71,7 @@ pkg_tar2rpm(
 pkg_tar2rpm(
     name = "rpmtest_withonlyonedir",
     data = ":rpmtest-tar-bothdirs",
-    dir_allowlist = ":dir_allowlist.txt",
+    dir_allowlist_file = ":dir_allowlist.txt",
     pkg_name = "rpmtest_withonlyonedir",
     use_dir_allowlist = True,
     version = "1.2",

--- a/example_bazel/BUILD.bazel
+++ b/example_bazel/BUILD.bazel
@@ -15,6 +15,24 @@ pkg_tar(
     package_dir = "var/lib/rpmpack",
 )
 
+pkg_tar(
+    name = "rpmtest-tar-otherdir",
+    srcs = [":content1.txt"],
+    mode = "0644",
+    ownername = "root.root",
+    package_dir = "/doesnot/exist/rpmpack",
+)
+
+pkg_tar(
+    name = "rpmtest-tar-bothdirs",
+    mode = "0644",
+    ownername = "root.root",
+    deps = [
+        ":rpmtest-tar",
+        ":rpmtest-tar-otherdir",
+    ],
+)
+
 pkg_tar2rpm(
     name = "rpmtest",
     data = ":rpmtest-tar",
@@ -33,6 +51,32 @@ pkg_tar2rpm(
     version = "1.2",
 )
 
+pkg_tar2rpm(
+    name = "rpmtest_bothdirs",
+    data = ":rpmtest-tar-bothdirs",
+    epoch = 42,
+    pkg_name = "rpmtest_bothdirs",
+    release = "3.4",
+    version = "1.2",
+)
+
+pkg_tar2rpm(
+    name = "rpmtest_withoutbothdirs",
+    data = ":rpmtest-tar-bothdirs",
+    pkg_name = "rpmtest_withoutbothdirs",
+    use_dir_allowlist = True,
+    version = "1.2",
+)
+
+pkg_tar2rpm(
+    name = "rpmtest_withonlyonedir",
+    data = ":rpmtest-tar-bothdirs",
+    dir_allowlist = ":dir_allowlist.txt",
+    pkg_name = "rpmtest_withonlyonedir",
+    use_dir_allowlist = True,
+    version = "1.2",
+)
+
 container_image(
     name = "centos_with_rpm",
     testonly = True,
@@ -40,6 +84,9 @@ container_image(
     directory = "/root/",
     files = [
         ":rpmtest.rpm",
+        ":rpmtest_bothdirs",
+        ":rpmtest_withonlyonedir",
+        ":rpmtest_withoutbothdirs",
         ":rpmtest_withtime",
     ],
     legacy_run_behavior = False,
@@ -114,6 +161,15 @@ sample3_link.txt
 """,
 )
 
+docker_diff(
+    name = "centos_rpmsample_directory_doesnotexist",
+    base = ":centos_with_rpmsample_executable",
+    cmd = "echo ===marker=== && /root/rpmsample > /root/rpmsample.rpm && rpm -i /root/rpmsample.rpm && cat /var/lib/thisdoesnotexist/sample.txt",
+    golden = """
+testsample
+""",
+)
+
 container_image(
     name = "fedora_with_rpm",
     testonly = True,
@@ -183,4 +239,40 @@ docker_diff(
     base = ":centos_with_rpm",
     cmd = "echo ===marker=== && rpm -i /root/rpmtest_withtime.rpm && rpm -q rpmtest_withtime --queryformat '%{BUILDTIME}\n'",
     golden = "17",
+)
+
+docker_diff(
+    name = "centos_bothdirs",
+    base = ":centos_with_rpm",
+    cmd = "echo ===marker===  && rpm -i --force /root/rpmtest_bothdirs.rpm && rpm -Vv rpmtest_bothdirs",
+    golden = """
+.........    /does
+.........    /does/not
+.........    /does/not/exist
+.........    /does/not/exist/rpmpack
+.........    /does/not/exist/rpmpack/content1.txt
+.........    /var
+.........    /var/lib
+.........    /var/lib/rpmpack
+.........    /var/lib/rpmpack/content1.txt""",
+)
+
+docker_diff(
+    name = "centos_withoutbothdirs",
+    base = ":centos_with_rpm",
+    cmd = "echo ===marker===  && rpm -i /root/rpmtest_withoutbothdirs.rpm && rpm -Vv rpmtest_withoutbothdirs",
+    golden = """
+.........    /does/not/exist/rpmpack/content1.txt
+.........    /var/lib/rpmpack/content1.txt""",
+)
+
+docker_diff(
+    name = "centos_withonlyonedir",
+    base = ":centos_with_rpm",
+    cmd = "echo ===marker===  && rpm -i /root/rpmtest_withonlyonedir.rpm && rpm -Vv rpmtest_withonlyonedir",
+    golden = """
+.........    /does/not/exist
+.........    /does/not/exist/rpmpack
+.........    /does/not/exist/rpmpack/content1.txt
+.........    /var/lib/rpmpack/content1.txt""",
 )

--- a/example_bazel/WORKSPACE
+++ b/example_bazel/WORKSPACE
@@ -86,6 +86,7 @@ container_pull(
     registry = "index.docker.io",
     repository = "library/centos",
 )
+
 container_pull(
     name = "fedora",
     digest = "sha256:3f3fc6a4714e44fae9147bc2b9542ac627491c13c4a3375e5066bdddc7710c9e",

--- a/example_bazel/dir_allowlist.txt
+++ b/example_bazel/dir_allowlist.txt
@@ -1,0 +1,2 @@
+/doesnot/exist/rpmpack
+/doesnot/exist

--- a/rpm.go
+++ b/rpm.go
@@ -219,6 +219,17 @@ func (r *RPM) FullVersion() string {
 	return r.Version
 }
 
+// AllowListDirs removes all directories which are not explicitly allowlisted.
+func (r *RPM) AllowListDirs(allowList map[string]bool) {
+	for fn, ff := range r.files {
+		if ff.Mode&040000 == 040000 {
+			if !allowList[fn] {
+				delete(r.files, fn)
+			}
+		}
+	}
+}
+
 // Write closes the rpm and writes the whole rpm to an io.Writer
 func (r *RPM) Write(w io.Writer) error {
 	if r.closed {

--- a/tar.go
+++ b/tar.go
@@ -57,13 +57,23 @@ func FromTar(inp io.Reader, md RPMMetaData) (*RPM, error) {
 		}
 		mtime := uint32(h.ModTime.Unix())
 
+    // Sometimes the tar has no uname and gname. RPM expects these to always exist.
+    owner := h.Uname
+    if owner == "" {
+      owner = "root"
+    }
+    group := h.Gname
+    if group == "" {
+     group = "root"
+    }
+
 		r.AddFile(
 			RPMFile{
 				Name:  path.Join("/", h.Name),
 				Body:  body,
 				Mode:  uint(h.Mode),
-				Owner: h.Uname,
-				Group: h.Gname,
+				Owner: owner,
+				Group: group,
 				MTime: mtime,
 			})
 	}


### PR DESCRIPTION
Users reported issues with installing rpms that have directories from the core filesystem (such as /etc/, /var/, etc). This change adds the option in `tar2rpm` and in the bazel rules, to only include certain directories. This talks about the directory itself, the content is always included.

Fixes #62 