### PR TITLE
bazel: replace cfg=host with cfg=exec.

### DIFF
--- a/def.bzl
+++ b/def.bzl
@@ -51,7 +51,7 @@ directories themselves if they are in the allowlist file. Using this without an 
         "dir_allowlist_file": attr.label(allow_single_file = True, doc = "A file with a list of directories to include in the rpm. The files contained in the directories are always added."),
         "tar2rpm": attr.label(
             default = Label("//cmd/tar2rpm"),
-            cfg = "host",
+            cfg = "exec",
             executable = True,
         ),
     },

--- a/example_bazel/testing.bzl
+++ b/example_bazel/testing.bzl
@@ -16,7 +16,7 @@ diff_test_expand = rule(
             mandatory = True,
             allow_single_file = True,
             executable = True,
-            cfg = "host",
+            cfg = "exec",
         ),
         "golden": attr.string(
             mandatory = True,


### PR DESCRIPTION
This is apparently how it's done these days. I could not find good docs or announcements, except for this: https://bazel.build/reference/command-line-reference#flag--incompatible_disable_starlark_host_transitions

But I did get a request from a Googler to change this.