### PR TITLE
Use modern go error wrapping instead of errors.Wrap.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -26,7 +26,6 @@ go_library(
         "@com_github_cavaliergopher_cpio//:cpio",
         "@com_github_klauspost_compress//zstd",
         "@com_github_klauspost_pgzip//:pgzip",
-        "@com_github_pkg_errors//:errors",
         "@com_github_ulikunitz_xz//:xz",
         "@com_github_ulikunitz_xz//lzma",
     ],

--- a/deps.bzl
+++ b/deps.bzl
@@ -31,12 +31,6 @@ def rpmpack_dependencies():
         sum = "h1:qnWYvvKqedOF2ulHpMG72XQol4ILEJ8k2wwRl/Km8oE=",
         version = "v1.2.5",
     )
-    go_repository(
-        name = "com_github_pkg_errors",
-        importpath = "github.com/pkg/errors",
-        sum = "h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=",
-        version = "v0.9.1",
-    )
 
     go_repository(
         name = "com_github_ulikunitz_xz",

--- a/go.mod
+++ b/go.mod
@@ -1,12 +1,11 @@
 module github.com/google/rpmpack
 
-go 1.12
+go 1.18
 
 require (
 	github.com/cavaliergopher/cpio v1.0.1
 	github.com/google/go-cmp v0.3.1
 	github.com/klauspost/compress v1.16.6
 	github.com/klauspost/pgzip v1.2.6
-	github.com/pkg/errors v0.9.1
 	github.com/ulikunitz/xz v0.5.11
 )

--- a/go.sum
+++ b/go.sum
@@ -6,7 +6,5 @@ github.com/klauspost/compress v1.16.6 h1:91SKEy4K37vkp255cJ8QesJhjyRO0hn9i9G0GoU
 github.com/klauspost/compress v1.16.6/go.mod h1:ntbaceVETuRiXiv4DpjP66DpAtAGkEQskQzEyD//IeE=
 github.com/klauspost/pgzip v1.2.6 h1:8RXeL5crjEUFnR2/Sn6GJNWtSQ3Dk8pq4CL3jvdDyjU=
 github.com/klauspost/pgzip v1.2.6/go.mod h1:Ch1tH69qFZu15pkjo5kYi6mth2Zzwzt50oCQKQE9RUs=
-github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
-github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/ulikunitz/xz v0.5.11 h1:kpFauv27b6ynzBNT/Xy+1k+fK4WswhN/6PN5WhFAGw8=
 github.com/ulikunitz/xz v0.5.11/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=

--- a/header.go
+++ b/header.go
@@ -19,8 +19,6 @@ import (
 	"encoding/binary"
 	"fmt"
 	"sort"
-
-	"github.com/pkg/errors"
 )
 
 const (
@@ -153,7 +151,7 @@ func (i *index) Bytes() ([]byte, error) {
 	// 4 count and 4 size
 	// We add the pseudo-entry "eigenHeader" to count.
 	if err := binary.Write(w, binary.BigEndian, []int32{int32(len(i.entries)) + 1, int32(entryData.Len())}); err != nil {
-		return nil, errors.Wrap(err, "failed to write eigenHeader")
+		return nil, fmt.Errorf("failed to write eigenHeader: %w", err)
 	}
 	// Write the eigenHeader index entry
 	w.Write(i.eigenHeader().indexBytes(i.h, entryData.Len()-0x10))

--- a/rpm.go
+++ b/rpm.go
@@ -20,6 +20,7 @@ package rpmpack
 import (
 	"bytes"
 	"crypto/sha256"
+	"errors"
 	"fmt"
 	"io"
 	"path"
@@ -31,7 +32,6 @@ import (
 	"github.com/cavaliergopher/cpio"
 	"github.com/klauspost/compress/zstd"
 	gzip "github.com/klauspost/pgzip"
-	"github.com/pkg/errors"
 	"github.com/ulikunitz/xz"
 	"github.com/ulikunitz/xz/lzma"
 )
@@ -243,18 +243,18 @@ func (r *RPM) Write(w io.Writer) error {
 	sort.Strings(fnames)
 	for _, fn := range fnames {
 		if err := r.writeFile(r.files[fn]); err != nil {
-			return errors.Wrapf(err, "failed to write file %q", fn)
+			return fmt.Errorf("failed to write file %q: %w", fn, err)
 		}
 	}
 	if err := r.cpio.Close(); err != nil {
-		return errors.Wrap(err, "failed to close cpio payload")
+		return fmt.Errorf("failed to close cpio payload: %w", err)
 	}
 	if err := r.compressedPayload.Close(); err != nil {
-		return errors.Wrap(err, "failed to close gzip payload")
+		return fmt.Errorf("failed to close gzip payload: %w", err)
 	}
 
 	if _, err := w.Write(lead(r.Name, r.FullVersion())); err != nil {
-		return errors.Wrap(err, "failed to write lead")
+		return fmt.Errorf("failed to write lead: %w", err)
 	}
 	// Write the regular header.
 	h := newIndex(immutable)
@@ -273,32 +273,35 @@ func (r *RPM) Write(w io.Writer) error {
 	h.AddEntries(r.customTags)
 	hb, err := h.Bytes()
 	if err != nil {
-		return errors.Wrap(err, "failed to retrieve header")
+		return fmt.Errorf("failed to retrieve header: %w", err)
 	}
 	// Write the signatures
 	s := newIndex(signatures)
 	if err := r.writeSignatures(s, hb); err != nil {
-		return errors.Wrap(err, "failed to create signatures")
+		return fmt.Errorf("failed to create signatures: %w", err)
 	}
 
 	s.AddEntries(r.customSigs)
 	sb, err := s.Bytes()
 	if err != nil {
-		return errors.Wrap(err, "failed to retrieve signatures header")
+		return fmt.Errorf("failed to retrieve signatures header: %w", err)
 	}
 
 	if _, err := w.Write(sb); err != nil {
-		return errors.Wrap(err, "failed to write signature bytes")
+		return fmt.Errorf("failed to write signature bytes: %w", err)
 	}
 	// Signatures are padded to 8-byte boundaries
 	if _, err := w.Write(make([]byte, (8-len(sb)%8)%8)); err != nil {
-		return errors.Wrap(err, "failed to write signature padding")
+		return fmt.Errorf("failed to write signature padding: %w", err)
 	}
 	if _, err := w.Write(hb); err != nil {
-		return errors.Wrap(err, "failed to write header body")
+		return fmt.Errorf("failed to write header body: %w", err)
 	}
-	_, err = w.Write(r.payload.Bytes())
-	return errors.Wrap(err, "failed to write payload")
+	if _, err := w.Write(r.payload.Bytes()); err != nil {
+		return fmt.Errorf("failed to write payload: %w", err)
+	}
+	return nil
+
 }
 
 // SetPGPSigner registers a function that will accept the header and payload as bytes,
@@ -318,14 +321,14 @@ func (r *RPM) writeSignatures(sigHeader *index, regHeader []byte) error {
 		header := append([]byte{}, regHeader...)
 		headerSig, err := r.pgpSigner(header)
 		if err != nil {
-			return errors.Wrap(err, "call to signer failed")
+			return fmt.Errorf("call to signer failed: %w", err)
 		}
 		sigHeader.Add(sigRSA, EntryBytes(headerSig))
 
 		body := append(header, r.payload.Bytes()...)
 		bodySig, err := r.pgpSigner(body)
 		if err != nil {
-			return errors.Wrap(err, "call to signer failed")
+			return fmt.Errorf("call to signer failed: %w", err)
 		}
 		sigHeader.Add(sigPGP, EntryBytes(bodySig))
 	}
@@ -335,22 +338,22 @@ func (r *RPM) writeSignatures(sigHeader *index, regHeader []byte) error {
 func (r *RPM) writeRelationIndexes(h *index) error {
 	// add all relation categories
 	if err := r.Provides.AddToIndex(h, tagProvides, tagProvideVersion, tagProvideFlags); err != nil {
-		return errors.Wrap(err, "failed to add provides")
+		return fmt.Errorf("failed to add provides: %w", err)
 	}
 	if err := r.Obsoletes.AddToIndex(h, tagObsoletes, tagObsoleteVersion, tagObsoleteFlags); err != nil {
-		return errors.Wrap(err, "failed to add obsoletes")
+		return fmt.Errorf("failed to add obsoletes: %w", err)
 	}
 	if err := r.Suggests.AddToIndex(h, tagSuggests, tagSuggestVersion, tagSuggestFlags); err != nil {
-		return errors.Wrap(err, "failed to add suggests")
+		return fmt.Errorf("failed to add suggests: %w", err)
 	}
 	if err := r.Recommends.AddToIndex(h, tagRecommends, tagRecommendVersion, tagRecommendFlags); err != nil {
-		return errors.Wrap(err, "failed to add recommends")
+		return fmt.Errorf("failed to add recommends: %w", err)
 	}
 	if err := r.Requires.AddToIndex(h, tagRequires, tagRequireVersion, tagRequireFlags); err != nil {
-		return errors.Wrap(err, "failed to add requires")
+		return fmt.Errorf("failed to add requires: %w", err)
 	}
 	if err := r.Conflicts.AddToIndex(h, tagConflicts, tagConflictVersion, tagConflictFlags); err != nil {
-		return errors.Wrap(err, "failed to add conflicts")
+		return fmt.Errorf("failed to add conflicts: %w", err)
 	}
 
 	return nil
@@ -540,10 +543,10 @@ func (r *RPM) writePayload(f RPMFile, links int) error {
 		Links: links,
 	}
 	if err := r.cpio.WriteHeader(hdr); err != nil {
-		return errors.Wrap(err, "failed to write payload file header")
+		return fmt.Errorf("failed to write payload file header: %w", err)
 	}
 	if _, err := r.cpio.Write(f.Body); err != nil {
-		return errors.Wrap(err, "failed to write payload file content")
+		return fmt.Errorf("failed to write payload file content: %w", err)
 	}
 	r.payloadSize += uint(len(f.Body))
 	return nil


### PR DESCRIPTION
nfpm uses errors.Is (since goreleaser/nfpm#630) and I want to undo the fork. Also updated the minimal go version (since this was introduced in 1.13)