### PR TITLE
fix: handle packager, vendor and others

### DIFF
--- a/rpm_test.go
+++ b/rpm_test.go
@@ -1,6 +1,7 @@
 package rpmpack
 
 import (
+	"bytes"
 	"io"
 	"reflect"
 	"testing"
@@ -178,5 +179,24 @@ func TestAllowListDirs(t *testing.T) {
 	expected := map[string]RPMFile{"/usr/local/dir1": {Name: "/usr/local/dir1", Mode: 040000}}
 	if d := cmp.Diff(expected, r.files); d != "" {
 		t.Errorf("Expected dirs differs (want->got):\n%v", d)
+	}
+}
+
+func TestMinimalSpec(t *testing.T) {
+	r, err := NewRPM(RPMMetaData{
+		Name:        "test",
+		Version:     "1.0",
+		Release:     "1",
+		Summary:     "test summary",
+		Description: "test description",
+		Licence:     "test license",
+	})
+	if err != nil {
+		t.Fatalf("NewRPM returned error %v", err)
+	}
+
+	var b bytes.Buffer
+	if err := r.Write(&b); err != nil {
+		t.Errorf("Write returned error %v", err)
 	}
 }


### PR DESCRIPTION
Packager, vendor, URL, and Epoch are being added to the headers even if they have no value and are not required.

This PR moves them to pointers, and add them if they are non-null values.

Could also not add them if they have their default value, which would not break anyone using the lib, but might be less clear, especially if someone wants to set epoch to 0, for example...

refs https://github.com/goreleaser/nfpm/issues/619