### PR TITLE
feat: add support for verifyscript tag

### DIFF
--- a/rpm.go
+++ b/rpm.go
@@ -63,7 +63,7 @@ type RPMMetaData struct {
 	BuildTime time.Time
 	// Prefixes is used for relocatable packages, usually with a one item
 	// slice, e.g. `["/opt"]`.
-	Prefixes  []string
+	Prefixes []string
 	Provides,
 	Obsoletes,
 	Suggests,
@@ -98,6 +98,7 @@ type RPM struct {
 	postun            string
 	pretrans          string
 	posttrans         string
+	verifyscript      string
 	customTags        map[int]IndexEntry
 	customSigs        map[int]IndexEntry
 	pgpSigner         func([]byte) ([]byte, error)
@@ -430,6 +431,10 @@ func (r *RPM) writeGenIndexes(h *index) {
 		h.Add(tagPosttrans, EntryString(r.posttrans))
 		h.Add(tagPosttransProg, EntryString("/bin/sh"))
 	}
+	if r.verifyscript != "" {
+		h.Add(tagVerifyScript, EntryString(r.verifyscript))
+		h.Add(tagVerifyScriptProg, EntryString("/bin/sh"))
+	}
 }
 
 // WriteFileIndexes writes file related index headers to the header
@@ -495,6 +500,11 @@ func (r *RPM) AddPostun(s string) {
 // AddPosttrans adds a posttrans scriptlet
 func (r *RPM) AddPosttrans(s string) {
 	r.posttrans = s
+}
+
+// AddVerifyScript adds a verifyscript scriptlet
+func (r *RPM) AddVerifyScript(s string) {
+	r.verifyscript = s
 }
 
 // AddFile adds an RPMFile to an existing rpm.

--- a/tags.go
+++ b/tags.go
@@ -68,11 +68,13 @@ const (
 	tagConflictFlags     = 0x041d // 1053
 	tagConflicts         = 0x041e // 1054
 	tagConflictVersion   = 0x041f // 1055
+	tagVerifyScript      = 0x0437 // 1079
 	tagPreinProg         = 0x043d // 1085
 	tagPostinProg        = 0x043e // 1086
 	tagPreunProg         = 0x043f // 1087
 	tagPostunProg        = 0x0440 // 1088
 	tagObsoletes         = 0x0442 // 1090
+	tagVerifyScriptProg  = 0x0443 // 1091
 	tagFileINodes        = 0x0448 // 1096
 	tagFileLangs         = 0x0449 // 1097
 	tagPrefixes          = 0x044a // 1098


### PR DESCRIPTION
The `verifyscript` tag is used to add scriptlets for RPM to execute when `rpm -V` is run to enable validation beyond the default file verification.