### PR TITLE
tar2rpm: add filename '-' as an alias for stdin and stdout

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,12 @@ This will make the `tar2rpm` tool available in `${GOPATH}/bin`, which by default
 
 ```
 Usage:
-  tar2rpm [OPTION] [FILE]
+  tar2rpm -name NAME -version VERSION [OPTION] [TARFILE]
+        Read tar content from stdin, or TARFILE if present. Write rpm to stdout, or the file given
+        by -file RPMFILE. If a filename is '-' use stdin/stdout without printing a notice.
 Options:
-  -file FILE
-        write rpm to FILE instead of stdout
+  -file RPMFILE
+        write rpm to RPMFILE instead of stdout
   -name string
         the package name
   -release string


### PR DESCRIPTION
When no filenames are given the informative message
"tar2pm: reading tar content from stdin, writing rpm data to stdout."
is printed to stderr. This can be suppressed by explicitly
specifying '-' for TARFILE and RPMFILE (if only TAR- or RPMFILE is
given the message reflects that).

Also updated usage() to reflect that, and rename FILE to
TARFILE/RPMFILE.
